### PR TITLE
Fix xml response for list-subscriptions-by-topic

### DIFF
--- a/app/sns_messages.go
+++ b/app/sns_messages.go
@@ -106,9 +106,9 @@ type ListSubscriptionsByTopicResult struct {
 }
 
 type ListSubscriptionsByTopicResponse struct {
-	Xmlns    string                  `xml:"xmlns,attr"`
-	Result   ListSubscriptionsResult `xml:"ListSubscriptionsResult"`
-	Metadata ResponseMetadata        `xml:"ResponseMetadata"`
+	Xmlns    string                         `xml:"xmlns,attr"`
+	Result   ListSubscriptionsByTopicResult `xml:"ListSubscriptionsByTopicResult"`
+	Metadata ResponseMetadata               `xml:"ResponseMetadata"`
 }
 
 /*** Publish ***/


### PR DESCRIPTION
XML response format is malformed for `list-subscriptions-by-topic`. Turns out the struct was defined but unused.

Reproduced by aws cli version 2.2.13 on macOS
```
aws --endpoint-url http://localhost:4100 --debug sns list-subscriptions-by-topic --topic-arn <topic_arn>
```