### PR TITLE
fix incorrect data type value of message attribute.

### DIFF
--- a/app/gosns/gosns.go
+++ b/app/gosns/gosns.go
@@ -554,7 +554,7 @@ func publishSQS(w http.ResponseWriter, req *http.Request,
 			msg.MessageAttributes = messageAttributes
 			msg.MD5OfMessageAttributes = common.HashAttributes(messageAttributes)
 			m, err := extractMessageFromJSON(messageBody, subs.Protocol)
-			if (err == nil) {
+			if err == nil {
 				msg.MessageBody = []byte(m)
 			} else {
 				msg.MessageBody = []byte(messageBody)
@@ -609,7 +609,7 @@ func formatAttributes(values map[string]app.MessageAttributeValue) map[string]ap
 	attr := make(map[string]app.MsgAttr)
 	for k, v := range values {
 		attr[k] = app.MsgAttr{
-			Type:  v.ValueKey,
+			Type:  v.DataType,
 			Value: v.Value,
 		}
 	}


### PR DESCRIPTION
When I published sns message with message attribute, DataType sould be `String` but `StringValue` is returned.

```
$ aws --endpoint-url http://127.0.0.1:4100 sns publish --message test --topic-arn arn:aws:sns:us-east-1:100010001000:local-topic1 --message-attributes '{"test":{"DataType": "String", "StringValue": "test!"}}'
```

```
$ aws --endpoint-url http://127.0.0.1:4100 sqs receive-message --queue-url http://us-east-1.goaws.com:4100/100010001000/local-queue3
{
    "Messages": [
        {
            "MessageId": "fb8a8253-36c6-4a4d-96be-e005f41240a5",
            "ReceiptHandle": "fb8a8253-36c6-4a4d-96be-e005f41240a5#1cce6f07-2ffa-4709-97bb-f8dff7584e52",
            "MD5OfBody": "99a983d00399afc3712ae7d82d13ca86",
            "Body": "{\"Type\":\"Notification\",\"Token\":\"\",\"MessageId\":\"b6cab133-ed2e-44e1-82fd-137e77aeaa7e\",\"TopicArn\":\"arn:aws:sns:us-east-1:100010001000:local-topic1\",\"Subject\":\"\",\"Message\":\"test\",\"Timestamp\":\"2022-02-25T06:02:21Z\",\"SignatureVersion\":\"1\",\"Signature\":\"HCOsu0ZkzgcXIbXdbTRpRY66JqP7haOe5QQjJ8xWROAPkRf7Hul8XlC5knwoAfaeEJ5jfR2rHalGiZm9zP9c50eq/zc2Sp9r0GcJBw/L+oKKmkEQ5p+guXG0nHMIFQPoUHwxQVnVfQV0T+mg+t3Q5k7FprHjgL2aI6QV57DSyRO1cpl9JwaR2INTDVoeRzs0xH6DWj8x6G4lZ5omyd/qUM1WEolDjOr+26wBwmkmoxVwGL1CQmdpHFTsp/tSrr/nn0DBp+zEHf19HGdal0ee9979XibwCzxzR2zUaEmonYctvkWdgzc//JroWkaFwvdrz64pIAfA7X3deNP2iCU9mA==\",\"SigningCertURL\":\"http://goaws.com:4100/SimpleNotificationService/b6cab133-ed2e-44e1-82fd-137e77aeaa7e.pem\",\"UnsubscribeURL\":\"http://goaws.com:4100/?Action=Unsubscribe\\u0026SubscriptionArn=arn:aws:sns:us-east-1:100010001000:local-topic1:489ddf06-1d3e-4e08-b3a3-be1dfc61e86f\",\"SubscribeURL\":\"\",\"MessageAttributes\":{\"test\":{\"Type\":\"StringValue\",\"Value\":\"test!\"}}}",
            "Attributes": {
                "SenderId": "100010001000",
                "ApproximateReceiveCount": "1",
                "SentTimestamp": "1645769010434",
                "ApproximateFirstReceiveTimestamp": "1645769007313"
            }
        }
    ]
}
```