### PR TITLE
allow for queue specific visibility time out configuration

### DIFF
--- a/app/common.go
+++ b/app/common.go
@@ -20,12 +20,13 @@ type EnvQueue struct {
 	ReceiveMessageWaitTimeSeconds int
 	RedrivePolicy                 string
 	MaximumMessageSize            int
+	VisibilityTimeout             int
 }
 
 type EnvQueueAttributes struct {
 	VisibilityTimeout             int
 	ReceiveMessageWaitTimeSeconds int
-	MaximumMessageSize						int
+	MaximumMessageSize            int
 }
 
 type Environment struct {
@@ -41,7 +42,7 @@ type Environment struct {
 	Topics                 []EnvTopic
 	Queues                 []EnvQueue
 	QueueAttributeDefaults EnvQueueAttributes
-	RandomLatency		   RandomLatency
+	RandomLatency          RandomLatency
 }
 
 var CurrentEnvironment Environment

--- a/app/conf/config.go
+++ b/app/conf/config.go
@@ -1,244 +1,248 @@
 package conf
 
 import (
-    "encoding/json"
-    "fmt"
-    "io/fs"
-    "os"
-    "path/filepath"
-    "strconv"
-    "strings"
-    "time"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
 
-    log "github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
-    "github.com/Admiral-Piett/goaws/app"
-    "github.com/Admiral-Piett/goaws/app/common"
-    "github.com/ghodss/yaml"
+	"github.com/Admiral-Piett/goaws/app"
+	"github.com/Admiral-Piett/goaws/app/common"
+	"github.com/ghodss/yaml"
 )
 
 var envs map[string]app.Environment
 
 func LoadYamlConfig(filename string, env string) []string {
-    ports := []string{"4100"}
+	ports := []string{"4100"}
 
-    if filename == "" {
-        root, _ := filepath.Abs(".")
-        err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
-            if "goaws.yaml" == d.Name() {
-                filename = path
-            }
-            return nil
-        })
-        if err != nil || filename == "" {
-            log.Warn("Failure to find default config file")
-            return ports
-        }
-    }
-    log.Infof("Loading config file: %s", filename)
-    yamlFile, err := os.ReadFile(filename)
-    if err != nil {
-        return ports
-    }
+	if filename == "" {
+		root, _ := filepath.Abs(".")
+		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if "goaws.yaml" == d.Name() {
+				filename = path
+			}
+			return nil
+		})
+		if err != nil || filename == "" {
+			log.Warn("Failure to find default config file")
+			return ports
+		}
+	}
+	log.Infof("Loading config file: %s", filename)
+	yamlFile, err := os.ReadFile(filename)
+	if err != nil {
+		return ports
+	}
 
-    err = yaml.Unmarshal(yamlFile, &envs)
-    if err != nil {
-        log.Errorf("err: %v\n", err)
-        return ports
-    }
-    if env == "" {
-        env = "Local"
-    }
+	err = yaml.Unmarshal(yamlFile, &envs)
+	if err != nil {
+		log.Errorf("err: %v\n", err)
+		return ports
+	}
+	if env == "" {
+		env = "Local"
+	}
 
-    if envs[env].Region == "" {
-        app.CurrentEnvironment.Region = "local"
-    }
+	if envs[env].Region == "" {
+		app.CurrentEnvironment.Region = "local"
+	}
 
-    app.CurrentEnvironment = envs[env]
+	app.CurrentEnvironment = envs[env]
 
-    if envs[env].Port != "" {
-        ports = []string{envs[env].Port}
-    } else if envs[env].SqsPort != "" && envs[env].SnsPort != "" {
-        ports = []string{envs[env].SqsPort, envs[env].SnsPort}
-        app.CurrentEnvironment.Port = envs[env].SqsPort
-    }
+	if envs[env].Port != "" {
+		ports = []string{envs[env].Port}
+	} else if envs[env].SqsPort != "" && envs[env].SnsPort != "" {
+		ports = []string{envs[env].SqsPort, envs[env].SnsPort}
+		app.CurrentEnvironment.Port = envs[env].SqsPort
+	}
 
-    common.LogMessages = false
-    common.LogFile = "./goaws_messages.log"
+	common.LogMessages = false
+	common.LogFile = "./goaws_messages.log"
 
-    if envs[env].LogToFile == true {
-        common.LogMessages = true
-        if envs[env].LogFile != "" {
-            common.LogFile = envs[env].LogFile
-        }
-    }
+	if envs[env].LogToFile == true {
+		common.LogMessages = true
+		if envs[env].LogFile != "" {
+			common.LogFile = envs[env].LogFile
+		}
+	}
 
-    if app.CurrentEnvironment.QueueAttributeDefaults.VisibilityTimeout == 0 {
-        app.CurrentEnvironment.QueueAttributeDefaults.VisibilityTimeout = 30
-    }
+	if app.CurrentEnvironment.QueueAttributeDefaults.VisibilityTimeout == 0 {
+		app.CurrentEnvironment.QueueAttributeDefaults.VisibilityTimeout = 30
+	}
 
-    if app.CurrentEnvironment.QueueAttributeDefaults.MaximumMessageSize == 0 {
-        app.CurrentEnvironment.QueueAttributeDefaults.MaximumMessageSize = 262144 // 256K
-    }
+	if app.CurrentEnvironment.QueueAttributeDefaults.MaximumMessageSize == 0 {
+		app.CurrentEnvironment.QueueAttributeDefaults.MaximumMessageSize = 262144 // 256K
+	}
 
-    if app.CurrentEnvironment.AccountID == "" {
-        app.CurrentEnvironment.AccountID = "queue"
-    }
+	if app.CurrentEnvironment.AccountID == "" {
+		app.CurrentEnvironment.AccountID = "queue"
+	}
 
-    if app.CurrentEnvironment.Host == "" {
-        app.CurrentEnvironment.Host = "localhost"
-        app.CurrentEnvironment.Port = "4100"
-    }
+	if app.CurrentEnvironment.Host == "" {
+		app.CurrentEnvironment.Host = "localhost"
+		app.CurrentEnvironment.Port = "4100"
+	}
 
-    app.SyncQueues.Lock()
-    app.SyncTopics.Lock()
-    for _, queue := range envs[env].Queues {
-        queueUrl := "http://" + app.CurrentEnvironment.Host + ":" + app.CurrentEnvironment.Port +
-            "/" + app.CurrentEnvironment.AccountID + "/" + queue.Name
-        if app.CurrentEnvironment.Region != "" {
-            queueUrl = "http://" + app.CurrentEnvironment.Region + "." + app.CurrentEnvironment.Host + ":" +
-                app.CurrentEnvironment.Port + "/" + app.CurrentEnvironment.AccountID + "/" + queue.Name
-        }
-        queueArn := "arn:aws:sqs:" + app.CurrentEnvironment.Region + ":" + app.CurrentEnvironment.AccountID + ":" + queue.Name
+	app.SyncQueues.Lock()
+	app.SyncTopics.Lock()
+	for _, queue := range envs[env].Queues {
+		queueUrl := "http://" + app.CurrentEnvironment.Host + ":" + app.CurrentEnvironment.Port +
+			"/" + app.CurrentEnvironment.AccountID + "/" + queue.Name
+		if app.CurrentEnvironment.Region != "" {
+			queueUrl = "http://" + app.CurrentEnvironment.Region + "." + app.CurrentEnvironment.Host + ":" +
+				app.CurrentEnvironment.Port + "/" + app.CurrentEnvironment.AccountID + "/" + queue.Name
+		}
+		queueArn := "arn:aws:sqs:" + app.CurrentEnvironment.Region + ":" + app.CurrentEnvironment.AccountID + ":" + queue.Name
 
-        if queue.ReceiveMessageWaitTimeSeconds == 0 {
-            queue.ReceiveMessageWaitTimeSeconds = app.CurrentEnvironment.QueueAttributeDefaults.ReceiveMessageWaitTimeSeconds
-        }
-        if queue.MaximumMessageSize == 0 {
-            queue.MaximumMessageSize = app.CurrentEnvironment.QueueAttributeDefaults.MaximumMessageSize
-        }
+		if queue.ReceiveMessageWaitTimeSeconds == 0 {
+			queue.ReceiveMessageWaitTimeSeconds = app.CurrentEnvironment.QueueAttributeDefaults.ReceiveMessageWaitTimeSeconds
+		}
+		if queue.MaximumMessageSize == 0 {
+			queue.MaximumMessageSize = app.CurrentEnvironment.QueueAttributeDefaults.MaximumMessageSize
+		}
 
-        app.SyncQueues.Queues[queue.Name] = &app.Queue{
-            Name:                queue.Name,
-            TimeoutSecs:         app.CurrentEnvironment.QueueAttributeDefaults.VisibilityTimeout,
-            Arn:                 queueArn,
-            URL:                 queueUrl,
-            ReceiveWaitTimeSecs: queue.ReceiveMessageWaitTimeSeconds,
-            MaximumMessageSize:  queue.MaximumMessageSize,
-            IsFIFO:              app.HasFIFOQueueName(queue.Name),
-            EnableDuplicates:    app.CurrentEnvironment.EnableDuplicates,
-            Duplicates:          make(map[string]time.Time),
-        }
-    }
+		if queue.VisibilityTimeout == 0 {
+			queue.VisibilityTimeout = app.CurrentEnvironment.QueueAttributeDefaults.VisibilityTimeout
+		}
 
-    // loop one more time to create queue's RedrivePolicy and assign deadletter queues in case dead letter queue is defined first in the config
-    for _, queue := range envs[env].Queues {
-        q := app.SyncQueues.Queues[queue.Name]
-        if queue.RedrivePolicy != "" {
-            err := setQueueRedrivePolicy(app.SyncQueues.Queues, q, queue.RedrivePolicy)
-            if err != nil {
-                log.Errorf("err: %s", err)
-                return ports
-            }
-        }
+		app.SyncQueues.Queues[queue.Name] = &app.Queue{
+			Name:                queue.Name,
+			TimeoutSecs:         queue.VisibilityTimeout,
+			Arn:                 queueArn,
+			URL:                 queueUrl,
+			ReceiveWaitTimeSecs: queue.ReceiveMessageWaitTimeSeconds,
+			MaximumMessageSize:  queue.MaximumMessageSize,
+			IsFIFO:              app.HasFIFOQueueName(queue.Name),
+			EnableDuplicates:    app.CurrentEnvironment.EnableDuplicates,
+			Duplicates:          make(map[string]time.Time),
+		}
+	}
 
-    }
+	// loop one more time to create queue's RedrivePolicy and assign deadletter queues in case dead letter queue is defined first in the config
+	for _, queue := range envs[env].Queues {
+		q := app.SyncQueues.Queues[queue.Name]
+		if queue.RedrivePolicy != "" {
+			err := setQueueRedrivePolicy(app.SyncQueues.Queues, q, queue.RedrivePolicy)
+			if err != nil {
+				log.Errorf("err: %s", err)
+				return ports
+			}
+		}
 
-    for _, topic := range envs[env].Topics {
-        topicArn := "arn:aws:sns:" + app.CurrentEnvironment.Region + ":" + app.CurrentEnvironment.AccountID + ":" + topic.Name
+	}
 
-        newTopic := &app.Topic{Name: topic.Name, Arn: topicArn}
-        newTopic.Subscriptions = make([]*app.Subscription, 0, 0)
+	for _, topic := range envs[env].Topics {
+		topicArn := "arn:aws:sns:" + app.CurrentEnvironment.Region + ":" + app.CurrentEnvironment.AccountID + ":" + topic.Name
 
-        for _, subs := range topic.Subscriptions {
-            var newSub *app.Subscription
-            if strings.Contains(subs.Protocol, "http") {
-                newSub = createHttpSubscription(subs)
-            } else {
-                //Queue does not exist yet, create it.
-                newSub = createSqsSubscription(subs, topicArn)
-            }
-            if subs.FilterPolicy != "" {
-                filterPolicy := &app.FilterPolicy{}
-                err = json.Unmarshal([]byte(subs.FilterPolicy), filterPolicy)
-                if err != nil {
-                    log.Errorf("err: %s", err)
-                    return ports
-                }
-                newSub.FilterPolicy = filterPolicy
-            }
+		newTopic := &app.Topic{Name: topic.Name, Arn: topicArn}
+		newTopic.Subscriptions = make([]*app.Subscription, 0, 0)
 
-            newTopic.Subscriptions = append(newTopic.Subscriptions, newSub)
-        }
-        app.SyncTopics.Topics[topic.Name] = newTopic
-    }
+		for _, subs := range topic.Subscriptions {
+			var newSub *app.Subscription
+			if strings.Contains(subs.Protocol, "http") {
+				newSub = createHttpSubscription(subs)
+			} else {
+				//Queue does not exist yet, create it.
+				newSub = createSqsSubscription(subs, topicArn)
+			}
+			if subs.FilterPolicy != "" {
+				filterPolicy := &app.FilterPolicy{}
+				err = json.Unmarshal([]byte(subs.FilterPolicy), filterPolicy)
+				if err != nil {
+					log.Errorf("err: %s", err)
+					return ports
+				}
+				newSub.FilterPolicy = filterPolicy
+			}
 
-    app.SyncQueues.Unlock()
-    app.SyncTopics.Unlock()
+			newTopic.Subscriptions = append(newTopic.Subscriptions, newSub)
+		}
+		app.SyncTopics.Topics[topic.Name] = newTopic
+	}
 
-    return ports
+	app.SyncQueues.Unlock()
+	app.SyncTopics.Unlock()
+
+	return ports
 }
 
 func createHttpSubscription(configSubscription app.EnvSubsciption) *app.Subscription {
-    newSub := &app.Subscription{EndPoint: configSubscription.EndPoint, Protocol: configSubscription.Protocol, TopicArn: configSubscription.TopicArn, Raw: configSubscription.Raw}
-    subArn, _ := common.NewUUID()
-    subArn = configSubscription.TopicArn + ":" + subArn
-    newSub.SubscriptionArn = subArn
-    return newSub
+	newSub := &app.Subscription{EndPoint: configSubscription.EndPoint, Protocol: configSubscription.Protocol, TopicArn: configSubscription.TopicArn, Raw: configSubscription.Raw}
+	subArn, _ := common.NewUUID()
+	subArn = configSubscription.TopicArn + ":" + subArn
+	newSub.SubscriptionArn = subArn
+	return newSub
 }
 
 func createSqsSubscription(configSubscription app.EnvSubsciption, topicArn string) *app.Subscription {
-    if _, ok := app.SyncQueues.Queues[configSubscription.QueueName]; !ok {
-        queueUrl := "http://" + app.CurrentEnvironment.Host + ":" + app.CurrentEnvironment.Port +
-            "/" + app.CurrentEnvironment.AccountID + "/" + configSubscription.QueueName
-        if app.CurrentEnvironment.Region != "" {
-            queueUrl = "http://" + app.CurrentEnvironment.Region + "." + app.CurrentEnvironment.Host + ":" +
-                app.CurrentEnvironment.Port + "/" + app.CurrentEnvironment.AccountID + "/" + configSubscription.QueueName
-        }
-        queueArn := "arn:aws:sqs:" + app.CurrentEnvironment.Region + ":" + app.CurrentEnvironment.AccountID + ":" + configSubscription.QueueName
-        app.SyncQueues.Queues[configSubscription.QueueName] = &app.Queue{
-            Name:                configSubscription.QueueName,
-            TimeoutSecs:         app.CurrentEnvironment.QueueAttributeDefaults.VisibilityTimeout,
-            Arn:                 queueArn,
-            URL:                 queueUrl,
-            ReceiveWaitTimeSecs: app.CurrentEnvironment.QueueAttributeDefaults.ReceiveMessageWaitTimeSeconds,
-            MaximumMessageSize:  app.CurrentEnvironment.QueueAttributeDefaults.MaximumMessageSize,
-            IsFIFO:              app.HasFIFOQueueName(configSubscription.QueueName),
-            EnableDuplicates:    app.CurrentEnvironment.EnableDuplicates,
-            Duplicates:          make(map[string]time.Time),
-        }
-    }
-    qArn := app.SyncQueues.Queues[configSubscription.QueueName].Arn
-    newSub := &app.Subscription{EndPoint: qArn, Protocol: "sqs", TopicArn: topicArn, Raw: configSubscription.Raw}
-    subArn, _ := common.NewUUID()
-    subArn = topicArn + ":" + subArn
-    newSub.SubscriptionArn = subArn
-    return newSub
+	if _, ok := app.SyncQueues.Queues[configSubscription.QueueName]; !ok {
+		queueUrl := "http://" + app.CurrentEnvironment.Host + ":" + app.CurrentEnvironment.Port +
+			"/" + app.CurrentEnvironment.AccountID + "/" + configSubscription.QueueName
+		if app.CurrentEnvironment.Region != "" {
+			queueUrl = "http://" + app.CurrentEnvironment.Region + "." + app.CurrentEnvironment.Host + ":" +
+				app.CurrentEnvironment.Port + "/" + app.CurrentEnvironment.AccountID + "/" + configSubscription.QueueName
+		}
+		queueArn := "arn:aws:sqs:" + app.CurrentEnvironment.Region + ":" + app.CurrentEnvironment.AccountID + ":" + configSubscription.QueueName
+		app.SyncQueues.Queues[configSubscription.QueueName] = &app.Queue{
+			Name:                configSubscription.QueueName,
+			TimeoutSecs:         app.CurrentEnvironment.QueueAttributeDefaults.VisibilityTimeout,
+			Arn:                 queueArn,
+			URL:                 queueUrl,
+			ReceiveWaitTimeSecs: app.CurrentEnvironment.QueueAttributeDefaults.ReceiveMessageWaitTimeSeconds,
+			MaximumMessageSize:  app.CurrentEnvironment.QueueAttributeDefaults.MaximumMessageSize,
+			IsFIFO:              app.HasFIFOQueueName(configSubscription.QueueName),
+			EnableDuplicates:    app.CurrentEnvironment.EnableDuplicates,
+			Duplicates:          make(map[string]time.Time),
+		}
+	}
+	qArn := app.SyncQueues.Queues[configSubscription.QueueName].Arn
+	newSub := &app.Subscription{EndPoint: qArn, Protocol: "sqs", TopicArn: topicArn, Raw: configSubscription.Raw}
+	subArn, _ := common.NewUUID()
+	subArn = topicArn + ":" + subArn
+	newSub.SubscriptionArn = subArn
+	return newSub
 }
 
 func setQueueRedrivePolicy(queues map[string]*app.Queue, q *app.Queue, strRedrivePolicy string) error {
-    // support both int and string maxReceiveCount (Amazon clients use string)
-    redrivePolicy1 := struct {
-        MaxReceiveCount     int    `json:"maxReceiveCount"`
-        DeadLetterTargetArn string `json:"deadLetterTargetArn"`
-    }{}
-    redrivePolicy2 := struct {
-        MaxReceiveCount     string `json:"maxReceiveCount"`
-        DeadLetterTargetArn string `json:"deadLetterTargetArn"`
-    }{}
-    err1 := json.Unmarshal([]byte(strRedrivePolicy), &redrivePolicy1)
-    err2 := json.Unmarshal([]byte(strRedrivePolicy), &redrivePolicy2)
-    maxReceiveCount := redrivePolicy1.MaxReceiveCount
-    deadLetterQueueArn := redrivePolicy1.DeadLetterTargetArn
-    if err1 != nil && err2 != nil {
-        return fmt.Errorf("invalid json for queue redrive policy ")
-    } else if err1 != nil {
-        maxReceiveCount, _ = strconv.Atoi(redrivePolicy2.MaxReceiveCount)
-        deadLetterQueueArn = redrivePolicy2.DeadLetterTargetArn
-    }
+	// support both int and string maxReceiveCount (Amazon clients use string)
+	redrivePolicy1 := struct {
+		MaxReceiveCount     int    `json:"maxReceiveCount"`
+		DeadLetterTargetArn string `json:"deadLetterTargetArn"`
+	}{}
+	redrivePolicy2 := struct {
+		MaxReceiveCount     string `json:"maxReceiveCount"`
+		DeadLetterTargetArn string `json:"deadLetterTargetArn"`
+	}{}
+	err1 := json.Unmarshal([]byte(strRedrivePolicy), &redrivePolicy1)
+	err2 := json.Unmarshal([]byte(strRedrivePolicy), &redrivePolicy2)
+	maxReceiveCount := redrivePolicy1.MaxReceiveCount
+	deadLetterQueueArn := redrivePolicy1.DeadLetterTargetArn
+	if err1 != nil && err2 != nil {
+		return fmt.Errorf("invalid json for queue redrive policy ")
+	} else if err1 != nil {
+		maxReceiveCount, _ = strconv.Atoi(redrivePolicy2.MaxReceiveCount)
+		deadLetterQueueArn = redrivePolicy2.DeadLetterTargetArn
+	}
 
-    if (deadLetterQueueArn != "" && maxReceiveCount == 0) ||
-        (deadLetterQueueArn == "" && maxReceiveCount != 0) {
-        return fmt.Errorf("invalid redrive policy values")
-    }
-    dlt := strings.Split(deadLetterQueueArn, ":")
-    deadLetterQueueName := dlt[len(dlt)-1]
-    deadLetterQueue, ok := queues[deadLetterQueueName]
-    if !ok {
-        return fmt.Errorf("deadletter queue not found")
-    }
-    q.DeadLetterQueue = deadLetterQueue
-    q.MaxReceiveCount = maxReceiveCount
+	if (deadLetterQueueArn != "" && maxReceiveCount == 0) ||
+		(deadLetterQueueArn == "" && maxReceiveCount != 0) {
+		return fmt.Errorf("invalid redrive policy values")
+	}
+	dlt := strings.Split(deadLetterQueueArn, ":")
+	deadLetterQueueName := dlt[len(dlt)-1]
+	deadLetterQueue, ok := queues[deadLetterQueueName]
+	if !ok {
+		return fmt.Errorf("deadletter queue not found")
+	}
+	q.DeadLetterQueue = deadLetterQueue
+	q.MaxReceiveCount = maxReceiveCount
 
-    return nil
+	return nil
 }

--- a/app/conf/config_test.go
+++ b/app/conf/config_test.go
@@ -1,152 +1,158 @@
 package conf
 
 import (
-    "github.com/stretchr/testify/assert"
-    "testing"
+	"testing"
 
-    "github.com/Admiral-Piett/goaws/app"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/Admiral-Piett/goaws/app"
 )
 
 func TestConfig_NoQueuesOrTopics(t *testing.T) {
-    env := "NoQueuesOrTopics"
-    port := LoadYamlConfig("./mock-data/mock-config.yaml", env)
-    if port[0] != "4100" {
-        t.Errorf("Expected port number 4200 but got %s\n", port)
-    }
+	env := "NoQueuesOrTopics"
+	port := LoadYamlConfig("./mock-data/mock-config.yaml", env)
+	if port[0] != "4100" {
+		t.Errorf("Expected port number 4200 but got %s\n", port)
+	}
 
-    numQueues := len(envs[env].Queues)
-    if numQueues != 0 {
-        t.Errorf("Expected zero queues to be in the environment but got %d\n", numQueues)
-    }
-    numQueues = len(app.SyncQueues.Queues)
-    if numQueues != 0 {
-        t.Errorf("Expected zero queues to be in the sqs topics but got %d\n", numQueues)
-    }
+	numQueues := len(envs[env].Queues)
+	if numQueues != 0 {
+		t.Errorf("Expected zero queues to be in the environment but got %d\n", numQueues)
+	}
+	numQueues = len(app.SyncQueues.Queues)
+	if numQueues != 0 {
+		t.Errorf("Expected zero queues to be in the sqs topics but got %d\n", numQueues)
+	}
 
-    numTopics := len(envs[env].Topics)
-    if numTopics != 0 {
-        t.Errorf("Expected zero topics to be in the environment but got %d\n", numTopics)
-    }
-    numTopics = len(app.SyncTopics.Topics)
-    if numTopics != 0 {
-        t.Errorf("Expected zero topics to be in the sns topics but got %d\n", numTopics)
-    }
+	numTopics := len(envs[env].Topics)
+	if numTopics != 0 {
+		t.Errorf("Expected zero topics to be in the environment but got %d\n", numTopics)
+	}
+	numTopics = len(app.SyncTopics.Topics)
+	if numTopics != 0 {
+		t.Errorf("Expected zero topics to be in the sns topics but got %d\n", numTopics)
+	}
 }
 
 func TestConfig_CreateQueuesTopicsAndSubscriptions(t *testing.T) {
-    env := "Local"
-    port := LoadYamlConfig("./mock-data/mock-config.yaml", env)
-    if port[0] != "4100" {
-        t.Errorf("Expected port number 4100 but got %s\n", port)
-    }
+	env := "Local"
+	port := LoadYamlConfig("./mock-data/mock-config.yaml", env)
+	if port[0] != "4100" {
+		t.Errorf("Expected port number 4100 but got %s\n", port)
+	}
 
-    numQueues := len(envs[env].Queues)
-    if numQueues != 4 {
-        t.Errorf("Expected three queues to be in the environment but got %d\n", numQueues)
-    }
-    numQueues = len(app.SyncQueues.Queues)
-    if numQueues != 6 {
-        t.Errorf("Expected five queues to be in the sqs topics but got %d\n", numQueues)
-    }
+	numQueues := len(envs[env].Queues)
+	if numQueues != 4 {
+		t.Errorf("Expected three queues to be in the environment but got %d\n", numQueues)
+	}
+	numQueues = len(app.SyncQueues.Queues)
+	if numQueues != 6 {
+		t.Errorf("Expected five queues to be in the sqs topics but got %d\n", numQueues)
+	}
 
-    numTopics := len(envs[env].Topics)
-    if numTopics != 2 {
-        t.Errorf("Expected two topics to be in the environment but got %d\n", numTopics)
-    }
-    numTopics = len(app.SyncTopics.Topics)
-    if numTopics != 2 {
-        t.Errorf("Expected two topics to be in the sns topics but got %d\n", numTopics)
-    }
+	numTopics := len(envs[env].Topics)
+	if numTopics != 2 {
+		t.Errorf("Expected two topics to be in the environment but got %d\n", numTopics)
+	}
+	numTopics = len(app.SyncTopics.Topics)
+	if numTopics != 2 {
+		t.Errorf("Expected two topics to be in the sns topics but got %d\n", numTopics)
+	}
 }
 
 func TestConfig_QueueAttributes(t *testing.T) {
-    env := "Local"
-    port := LoadYamlConfig("./mock-data/mock-config.yaml", env)
-    if port[0] != "4100" {
-        t.Errorf("Expected port number 4100 but got %s\n", port)
-    }
+	env := "Local"
+	port := LoadYamlConfig("./mock-data/mock-config.yaml", env)
+	if port[0] != "4100" {
+		t.Errorf("Expected port number 4100 but got %s\n", port)
+	}
 
-    receiveWaitTime := app.SyncQueues.Queues["local-queue1"].ReceiveWaitTimeSecs
-    if receiveWaitTime != 10 {
-        t.Errorf("Expected local-queue1 Queue to be configured with ReceiveMessageWaitTimeSeconds: 10 but got %d\n", receiveWaitTime)
-    }
-    timeoutSecs := app.SyncQueues.Queues["local-queue1"].TimeoutSecs
-    if timeoutSecs != 10 {
-        t.Errorf("Expected local-queue1 Queue to be configured with VisibilityTimeout: 10 but got %d\n", timeoutSecs)
-    }
-    maximumMessageSize := app.SyncQueues.Queues["local-queue1"].MaximumMessageSize
-    if maximumMessageSize != 1024 {
-        t.Errorf("Expected local-queue1 Queue to be configured with MaximumMessageSize: 1024 but got %d\n", maximumMessageSize)
-    }
+	receiveWaitTime := app.SyncQueues.Queues["local-queue1"].ReceiveWaitTimeSecs
+	if receiveWaitTime != 10 {
+		t.Errorf("Expected local-queue1 Queue to be configured with ReceiveMessageWaitTimeSeconds: 10 but got %d\n", receiveWaitTime)
+	}
+	timeoutSecs := app.SyncQueues.Queues["local-queue1"].TimeoutSecs
+	if timeoutSecs != 10 {
+		t.Errorf("Expected local-queue1 Queue to be configured with VisibilityTimeout: 10 but got %d\n", timeoutSecs)
+	}
+	maximumMessageSize := app.SyncQueues.Queues["local-queue1"].MaximumMessageSize
+	if maximumMessageSize != 1024 {
+		t.Errorf("Expected local-queue1 Queue to be configured with MaximumMessageSize: 1024 but got %d\n", maximumMessageSize)
+	}
 
-    if app.SyncQueues.Queues["local-queue1"].DeadLetterQueue != nil {
-        t.Errorf("Expected local-queue1 Queue to be configured without redrive policy\n")
-    }
-    if app.SyncQueues.Queues["local-queue1"].MaxReceiveCount != 0 {
-        t.Errorf("Expected local-queue1 Queue to be configured without redrive policy and therefore MaxReceiveCount: 0 \n")
-    }
+	if app.SyncQueues.Queues["local-queue1"].DeadLetterQueue != nil {
+		t.Errorf("Expected local-queue1 Queue to be configured without redrive policy\n")
+	}
+	if app.SyncQueues.Queues["local-queue1"].MaxReceiveCount != 0 {
+		t.Errorf("Expected local-queue1 Queue to be configured without redrive policy and therefore MaxReceiveCount: 0 \n")
+	}
 
-    maxReceiveCount := app.SyncQueues.Queues["local-queue3"].MaxReceiveCount
-    if maxReceiveCount != 100 {
-        t.Errorf("Expected local-queue2 Queue to be configured with MaxReceiveCount: 3 from RedrivePolicy but got %d\n", maxReceiveCount)
-    }
-    dlq := app.SyncQueues.Queues["local-queue3"].DeadLetterQueue
-    if dlq == nil {
-        t.Errorf("Expected local-queue3 to have one dead letter queue to redrive to\n")
-    }
-    if dlq.Name != "local-queue3-dlq" {
-        t.Errorf("Expected local-queue3 to have dead letter queue local-queue3-dlq but got %s\n", dlq.Name)
-    }
-    maximumMessageSize = app.SyncQueues.Queues["local-queue2"].MaximumMessageSize
-    if maximumMessageSize != 128 {
-        t.Errorf("Expected local-queue1 Queue to be configured with MaximumMessageSize: 128 but got %d\n", maximumMessageSize)
-    }
+	maxReceiveCount := app.SyncQueues.Queues["local-queue3"].MaxReceiveCount
+	if maxReceiveCount != 100 {
+		t.Errorf("Expected local-queue2 Queue to be configured with MaxReceiveCount: 3 from RedrivePolicy but got %d\n", maxReceiveCount)
+	}
+	dlq := app.SyncQueues.Queues["local-queue3"].DeadLetterQueue
+	if dlq == nil {
+		t.Errorf("Expected local-queue3 to have one dead letter queue to redrive to\n")
+	}
+	if dlq.Name != "local-queue3-dlq" {
+		t.Errorf("Expected local-queue3 to have dead letter queue local-queue3-dlq but got %s\n", dlq.Name)
+	}
+	maximumMessageSize = app.SyncQueues.Queues["local-queue2"].MaximumMessageSize
+	if maximumMessageSize != 128 {
+		t.Errorf("Expected local-queue2 Queue to be configured with MaximumMessageSize: 128 but got %d\n", maximumMessageSize)
+	}
+
+	timeoutSecs = app.SyncQueues.Queues["local-queue2"].TimeoutSecs
+	if timeoutSecs != 150 {
+		t.Errorf("Expected local-queue2 Queue to be configured with VisibilityTimeout: 150 but got %d\n", timeoutSecs)
+	}
 }
 
 func TestConfig_NoQueueAttributeDefaults(t *testing.T) {
-    env := "NoQueueAttributeDefaults"
-    LoadYamlConfig("./mock-data/mock-config.yaml", env)
+	env := "NoQueueAttributeDefaults"
+	LoadYamlConfig("./mock-data/mock-config.yaml", env)
 
-    receiveWaitTime := app.SyncQueues.Queues["local-queue1"].ReceiveWaitTimeSecs
-    if receiveWaitTime != 0 {
-        t.Errorf("Expected local-queue1 Queue to be configured with ReceiveMessageWaitTimeSeconds: 0 but got %d\n", receiveWaitTime)
-    }
-    timeoutSecs := app.SyncQueues.Queues["local-queue1"].TimeoutSecs
-    if timeoutSecs != 30 {
-        t.Errorf("Expected local-queue1 Queue to be configured with VisibilityTimeout: 30 but got %d\n", timeoutSecs)
-    }
+	receiveWaitTime := app.SyncQueues.Queues["local-queue1"].ReceiveWaitTimeSecs
+	if receiveWaitTime != 0 {
+		t.Errorf("Expected local-queue1 Queue to be configured with ReceiveMessageWaitTimeSeconds: 0 but got %d\n", receiveWaitTime)
+	}
+	timeoutSecs := app.SyncQueues.Queues["local-queue1"].TimeoutSecs
+	if timeoutSecs != 30 {
+		t.Errorf("Expected local-queue1 Queue to be configured with VisibilityTimeout: 30 but got %d\n", timeoutSecs)
+	}
 
-    receiveWaitTime = app.SyncQueues.Queues["local-queue2"].ReceiveWaitTimeSecs
-    if receiveWaitTime != 20 {
-        t.Errorf("Expected local-queue2 Queue to be configured with ReceiveMessageWaitTimeSeconds: 20 but got %d\n", receiveWaitTime)
-    }
+	receiveWaitTime = app.SyncQueues.Queues["local-queue2"].ReceiveWaitTimeSecs
+	if receiveWaitTime != 20 {
+		t.Errorf("Expected local-queue2 Queue to be configured with ReceiveMessageWaitTimeSeconds: 20 but got %d\n", receiveWaitTime)
+	}
 }
 
 func TestConfig_LoadYamlConfig_finds_default_config(t *testing.T) {
-    expectedQueues := []string{
-        "local-queue1",
-        "local-queue2",
-        "local-queue3",
-        "local-queue4",
-    }
-    expectedTopics := []string{
-        "local-topic1",
-        "sub-topic",
-        "local-topic2",
-        "my_topic",
-    }
+	expectedQueues := []string{
+		"local-queue1",
+		"local-queue2",
+		"local-queue3",
+		"local-queue4",
+	}
+	expectedTopics := []string{
+		"local-topic1",
+		"sub-topic",
+		"local-topic2",
+		"my_topic",
+	}
 
-    env := "Local"
-    LoadYamlConfig("", env)
+	env := "Local"
+	LoadYamlConfig("", env)
 
-    queues := app.SyncQueues.Queues
-    topics := app.SyncTopics.Topics
-    for _, expectedName := range expectedQueues {
-        _, ok := queues[expectedName]
-        assert.True(t, ok)
-    }
-    for _, expectedName := range expectedTopics {
-        _, ok := topics[expectedName]
-        assert.True(t, ok)
-    }
+	queues := app.SyncQueues.Queues
+	topics := app.SyncTopics.Topics
+	for _, expectedName := range expectedQueues {
+		_, ok := queues[expectedName]
+		assert.True(t, ok)
+	}
+	for _, expectedName := range expectedTopics {
+		_, ok := topics[expectedName]
+		assert.True(t, ok)
+	}
 }

--- a/app/conf/mock-data/mock-config.yaml
+++ b/app/conf/mock-data/mock-config.yaml
@@ -1,34 +1,35 @@
-Local:                              # Environment name that can be passed on the command line
+Local: # Environment name that can be passed on the command line
   #     (i.e.: ./goaws [Local | Dev]  -- defaults to 'Local')
-  Host: localhost                   # hostname of the goaws system  (for docker-compose this is the tag name of the container)
-  Port: 4100                        # port to listen on.
+  Host: localhost # hostname of the goaws system  (for docker-compose this is the tag name of the container)
+  Port: 4100 # port to listen on.
   Region: us-east-1
   AccountId: "100010001000"
-  LogMessages: true                 # Log messages (true/false)
-  LogFile: ./goaws_messages.log     # Log filename (for message logging
-  QueueAttributeDefaults:           # default attributes for all queues
-    VisibilityTimeout: 10              # message visibility timeout
-    ReceiveMessageWaitTimeSeconds: 10  # receive message max wait time
-    MaximumMessageSize: 1024           # maximum message size (bytes)
-  Queues:                           # List of queues to create at startup
-    - Name: local-queue1                # Queue name
-    - Name: local-queue2                # Queue name
+  LogMessages: true # Log messages (true/false)
+  LogFile: ./goaws_messages.log # Log filename (for message logging
+  QueueAttributeDefaults: # default attributes for all queues
+    VisibilityTimeout: 10 # message visibility timeout
+    ReceiveMessageWaitTimeSeconds: 10 # receive message max wait time
+    MaximumMessageSize: 1024 # maximum message size (bytes)
+  Queues: # List of queues to create at startup
+    - Name: local-queue1 # Queue name
+    - Name: local-queue2 # Queue name
       ReceiveMessageWaitTimeSeconds: 20 # Queue receive message max wait time
-      MaximumMessageSize: 128           # Queue maximum message size (bytes)
-    - Name: local-queue3                # Queue name
-      RedrivePolicy: '{"maxReceiveCount": 100, "deadLetterTargetArn":"arn:aws:sqs:us-east-1:000000000000:local-queue3-dlq"}'  
-    - Name: local-queue3-dlq            # Queue name      
-  Topics:                           # List of topic to create at startup
-    - Name: local-topic1            # Topic name - with some Subscriptions
-      Subscriptions:                # List of Subscriptions to create for this topic (queues will be created as required)
-        - QueueName: local-queue4   # Queue name
-          Raw: false                # Raw message delivery (true/false)
-        - QueueName: local-queue5   # Queue name
-          Raw: true                 # Raw message delivery (true/false)
+      MaximumMessageSize: 128 # Queue maximum message size (bytes)
+      VisibilityTimeout: 150 # Queue visibility timeout
+    - Name: local-queue3 # Queue name
+      RedrivePolicy: '{"maxReceiveCount": 100, "deadLetterTargetArn":"arn:aws:sqs:us-east-1:000000000000:local-queue3-dlq"}'
+    - Name: local-queue3-dlq # Queue name
+  Topics: # List of topic to create at startup
+    - Name: local-topic1 # Topic name - with some Subscriptions
+      Subscriptions: # List of Subscriptions to create for this topic (queues will be created as required)
+        - QueueName: local-queue4 # Queue name
+          Raw: false # Raw message delivery (true/false)
+        - QueueName: local-queue5 # Queue name
+          Raw: true # Raw message delivery (true/false)
           FilterPolicy: '{"foo":["bar"]}' # Subscription's FilterPolicy, json like a string
-    - Name: local-topic2            # Topic name - no Subscriptions
+    - Name: local-topic2 # Topic name - no Subscriptions
 
-NoQueuesOrTopics:                   # Another environment
+NoQueuesOrTopics: # Another environment
   Host: localhost
   Port: 4100
   LogMessages: true


### PR DESCRIPTION
Currently there can only be a single VisibilityTimeout configuration that affects all queues. However in real life situations, some queues process more complex data than others requiring queue specific VisibilityTimeout settings. This PR simply updates the configuration so that queue specific visibility timeouts are also accepted