### PR TITLE
Fix erroneous "not found" responses in DeleteMessageBatch

### DIFF
--- a/app/gosqs/gosqs.go
+++ b/app/gosqs/gosqs.go
@@ -644,16 +644,16 @@ func DeleteMessageBatch(w http.ResponseWriter, req *http.Request) {
 
 	app.SyncQueues.Lock()
 	if _, ok := app.SyncQueues.Queues[queueName]; ok {
-		for _, deleteEntry := range deleteEntries {
-			for i, msg := range app.SyncQueues.Queues[queueName].Messages {
+		for entryi, deleteEntry := range deleteEntries {
+			for msgi, msg := range app.SyncQueues.Queues[queueName].Messages {
 				if msg.ReceiptHandle == deleteEntry.ReceiptHandle {
 					// Unlock messages for the group
 					log.Printf("FIFO Queue %s unlocking group %s:", queueName, msg.GroupID)
 					app.SyncQueues.Queues[queueName].UnlockGroup(msg.GroupID)
-					app.SyncQueues.Queues[queueName].Messages = append(app.SyncQueues.Queues[queueName].Messages[:i], app.SyncQueues.Queues[queueName].Messages[i+1:]...)
+					app.SyncQueues.Queues[queueName].Messages = append(app.SyncQueues.Queues[queueName].Messages[:msgi], app.SyncQueues.Queues[queueName].Messages[msgi+1:]...)
 					delete(app.SyncQueues.Queues[queueName].Duplicates, msg.DeduplicationID)
 
-					deleteEntry.Deleted = true
+					deleteEntries[entryi].Deleted = true
 					deletedEntry := app.DeleteMessageBatchResultEntry{Id: deleteEntry.Id}
 					deletedEntries = append(deletedEntries, deletedEntry)
 					break


### PR DESCRIPTION
When looping through messages, the "deleted" indicator was being updated in the copy of deleteEntry within the loop rather than updating the slice which is later used to append "not found" errors, so both successes and fails were being returned.