### PR TITLE
Include Owner value in Subscriptions and SubscriptionsByTopic responses

### DIFF
--- a/app/gosns/gosns.go
+++ b/app/gosns/gosns.go
@@ -306,7 +306,7 @@ func ListSubscriptions(w http.ResponseWriter, req *http.Request) {
 	for _, topic := range app.SyncTopics.Topics {
 		for _, sub := range topic.Subscriptions {
 			tar := app.TopicMemberResult{TopicArn: topic.Arn, Protocol: sub.Protocol,
-				SubscriptionArn: sub.SubscriptionArn, Endpoint: sub.EndPoint}
+				SubscriptionArn: sub.SubscriptionArn, Endpoint: sub.EndPoint, Owner: app.CurrentEnvironment.AccountID}
 			respStruct.Result.Subscriptions.Member = append(respStruct.Result.Subscriptions.Member, tar)
 		}
 	}
@@ -330,7 +330,7 @@ func ListSubscriptionsByTopic(w http.ResponseWriter, req *http.Request) {
 
 		for _, sub := range topic.Subscriptions {
 			tar := app.TopicMemberResult{TopicArn: topic.Arn, Protocol: sub.Protocol,
-				SubscriptionArn: sub.SubscriptionArn, Endpoint: sub.EndPoint}
+				SubscriptionArn: sub.SubscriptionArn, Endpoint: sub.EndPoint, Owner: app.CurrentEnvironment.AccountID}
 			respStruct.Result.Subscriptions.Member = append(respStruct.Result.Subscriptions.Member, tar)
 		}
 		SendResponseBack(w, req, respStruct, content)

--- a/app/gosns/gosns_test.go
+++ b/app/gosns/gosns_test.go
@@ -385,6 +385,82 @@ func TestPublish_No_Queue_Error_handler_POST_Success(t *testing.T) {
 	}
 }
 
+func TestListSubscriptionByTopicResponse_No_Owner(t *testing.T) {
+
+	// set accountID to test value so it can be populated in response
+	app.CurrentEnvironment.AccountID = "100010001000"
+
+	// Create a request to pass to our handler. We don't have any query parameters for now, so we'll
+	// pass 'nil' as the third parameter.
+	req, err := http.NewRequest("POST", "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	form := url.Values{}
+	form.Add("TopicArn", "arn:aws:sns:local:000000000000:UnitTestTopic1")
+	req.PostForm = form
+
+	// We create a ResponseRecorder (which satisfies http.ResponseWriter) to record the response.
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(ListSubscriptionsByTopic)
+
+	// Our handlers satisfy http.Handler, so we can call their ServeHTTP method
+	// directly and pass in our Request and ResponseRecorder.
+	handler.ServeHTTP(rr, req)
+
+	// Check the status code is what we expect.
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusOK)
+	}
+
+	// Check the response body is what we expect.
+	expected := `<Owner>` + app.CurrentEnvironment.AccountID + `</Owner>`
+	if !strings.Contains(rr.Body.String(), expected) {
+		t.Errorf("handler returned empty owner for subscription member: got %v want %v",
+			rr.Body.String(), expected)
+	}
+}
+
+func TestListSubscriptionsResponse_No_Owner(t *testing.T) {
+
+	// set accountID to test value so it can be populated in response
+	app.CurrentEnvironment.AccountID = "100010001000"
+
+	// Create a request to pass to our handler. We don't have any query parameters for now, so we'll
+	// pass 'nil' as the third parameter.
+	req, err := http.NewRequest("POST", "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	form := url.Values{}
+	form.Add("TopicArn", "arn:aws:sns:local:000000000000:UnitTestTopic1")
+	req.PostForm = form
+
+	// We create a ResponseRecorder (which satisfies http.ResponseWriter) to record the response.
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(ListSubscriptions)
+
+	// Our handlers satisfy http.Handler, so we can call their ServeHTTP method
+	// directly and pass in our Request and ResponseRecorder.
+	handler.ServeHTTP(rr, req)
+
+	// Check the status code is what we expect.
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusOK)
+	}
+
+	// Check the response body is what we expect.
+	expected := `<Owner>` + app.CurrentEnvironment.AccountID + `</Owner>`
+	if !strings.Contains(rr.Body.String(), expected) {
+		t.Errorf("handler returned empty owner for subscription member: got %v want %v",
+			rr.Body.String(), expected)
+	}
+}
+
 func TestDeleteTopichandler_POST_Success(t *testing.T) {
 	// Create a request to pass to our handler. We don't have any query parameters for now, so we'll
 	// pass 'nil' as the third parameter.


### PR DESCRIPTION
I added the `Owner` field for both the `ListSubscriptions` and `ListSubscriptionsByTopic` requests, as well as added tests to confirm the field is populated with the expected value in the response.

---
-> `ListSubscriptions`

<img width="894" alt="image" src="https://github.com/Admiral-Piett/goaws/assets/87335859/3e5dd26d-fb56-423e-87dc-863519781b72">

---
-> `ListSubscriptionsByTopic`

<img width="908" alt="image" src="https://github.com/Admiral-Piett/goaws/assets/87335859/4a9681e3-1538-48f3-abf2-8c67814c29d7">

> Note - sorry it took so long to get to this one!! Luckily the changes were pretty straightforward, and the tests are passing smoothly. Let me know if you have any questions 👍 