### PR TITLE
Include HEALTHCHECK in Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,8 @@ COPY --from=build /go/src/github.com/Admiral-Piett/goaws/goaws ./goaws
 COPY app/conf/goaws.yaml ./conf/
 
 EXPOSE 4100
+
+HEALTHCHECK --interval=5s --timeout=3s --retries=3 \
+  CMD wget localhost:4100/health -q -O - > /dev/null
+  
 ENTRYPOINT ["./goaws"]


### PR DESCRIPTION
This change includes a healthcheck in the `Dockerfile` to ensure the container starts in a healthy state before being ready to serve requests. Thanks to issue #258 for the suggestion.

```
cdaly@9:24:52 ‹ docker_healtcheck ● › : ~/GITHome/goaws
[0] % docker run -d 6bb46d55f31b
7587581446d66df072aef7ab5c6ba30b88f14c91ec72cb0c2fa4c7ccc7cf25cd

cdaly@9:25:05 ‹ docker_healtcheck ● › : ~/GITHome/goaws
[0] % docker ps
CONTAINER ID   IMAGE          COMMAND     CREATED        STATUS                           PORTS      NAMES
7587581446d6   6bb46d55f31b   "./goaws"   1 second ago   Up 1 second (health: starting)   4100/tcp   quirky_yalow

cdaly@9:25:07 ‹ docker_healtcheck ● › : ~/GITHome/goaws
[0] % docker ps
CONTAINER ID   IMAGE          COMMAND     CREATED         STATUS                            PORTS      NAMES
7587581446d6   6bb46d55f31b   "./goaws"   4 seconds ago   Up 3 seconds (health: starting)   4100/tcp   quirky_yalow

cdaly@9:25:09 ‹ docker_healtcheck ● › : ~/GITHome/goaws
[0] % docker ps
CONTAINER ID   IMAGE          COMMAND     CREATED         STATUS                   PORTS      NAMES
7587581446d6   6bb46d55f31b   "./goaws"   5 seconds ago   Up 5 seconds (healthy)   4100/tcp   quirky_yalow
```