### PR TITLE
[aws-json] Migrate SQS SendMessage

### DIFF
--- a/app/gosqs/message_attributes.go
+++ b/app/gosqs/message_attributes.go
@@ -1,46 +1,8 @@
 package gosqs
 
 import (
-	"fmt"
-	"net/http"
-
 	"github.com/Admiral-Piett/goaws/app"
-	log "github.com/sirupsen/logrus"
 )
-
-func extractMessageAttributes(req *http.Request, prefix string) map[string]app.MessageAttributeValue {
-	attributes := make(map[string]app.MessageAttributeValue)
-	if prefix != "" {
-		prefix += "."
-	}
-
-	for i := 1; true; i++ {
-		name := req.FormValue(fmt.Sprintf("%sMessageAttribute.%d.Name", prefix, i))
-		if name == "" {
-			break
-		}
-
-		dataType := req.FormValue(fmt.Sprintf("%sMessageAttribute.%d.Value.DataType", prefix, i))
-		if dataType == "" {
-			log.Warnf("DataType of MessageAttribute %s is missing, MD5 checksum will most probably be wrong!\n", name)
-			continue
-		}
-
-		// StringListValue and BinaryListValue is currently not implemented
-		for _, valueKey := range [...]string{"StringValue", "BinaryValue"} {
-			value := req.FormValue(fmt.Sprintf("%sMessageAttribute.%d.Value.%s", prefix, i, valueKey))
-			if value != "" {
-				attributes[name] = app.MessageAttributeValue{name, dataType, value, valueKey}
-			}
-		}
-
-		if _, ok := attributes[name]; !ok {
-			log.Warnf("StringValue or BinaryValue of MessageAttribute %s is missing, MD5 checksum will most probably be wrong!\n", name)
-		}
-	}
-
-	return attributes
-}
 
 func getMessageAttributeResult(a *app.MessageAttributeValue) *app.ResultMessageAttribute {
 	v := &app.ResultMessageAttributeValue{

--- a/app/gosqs/send_message.go
+++ b/app/gosqs/send_message.go
@@ -1,0 +1,133 @@
+package gosqs
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Admiral-Piett/goaws/app/interfaces"
+	"github.com/Admiral-Piett/goaws/app/models"
+
+	"github.com/Admiral-Piett/goaws/app/utils"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/Admiral-Piett/goaws/app"
+	"github.com/Admiral-Piett/goaws/app/common"
+	"github.com/gorilla/mux"
+)
+
+func SendMessageV1(req *http.Request) (int, interfaces.AbstractResponseBody) {
+	requestBody := models.NewSendMessageRequest()
+	ok := utils.REQUEST_TRANSFORMER(requestBody, req)
+	if !ok {
+		log.Error("Invalid Request - CreateQueueV1")
+		return createErrorResponseV1(ErrInvalidParameterValue.Type)
+	}
+	messageBody := requestBody.MessageBody
+	messageGroupID := requestBody.MessageGroupId
+	messageDeduplicationID := requestBody.MessageDeduplicationId
+	messageAttributes := requestBody.MessageAttributes
+
+	queueUrl := getQueueFromPath(requestBody.QueueUrl, req.URL.String())
+
+	queueName := ""
+	if queueUrl == "" {
+		// TODO: Remove this query param logic if it's not still valid or something
+		vars := mux.Vars(req)
+		queueName = vars["queueName"]
+	} else {
+		uriSegments := strings.Split(queueUrl, "/")
+		queueName = uriSegments[len(uriSegments)-1]
+	}
+
+	if _, ok := app.SyncQueues.Queues[queueName]; !ok {
+		// Queue does not exist
+		return createErrorResponseV1("QueueNotFound")
+	}
+
+	if app.SyncQueues.Queues[queueName].MaximumMessageSize > 0 &&
+		len(messageBody) > app.SyncQueues.Queues[queueName].MaximumMessageSize {
+		// Message size is too big
+		return createErrorResponseV1("MessageTooBig")
+	}
+
+	delaySecs := app.SyncQueues.Queues[queueName].DelaySeconds
+	if requestBody.DelaySeconds != 0 {
+		delaySecs = requestBody.DelaySeconds
+	}
+
+	log.Debugf("Putting Message in Queue: [%s]", queueName)
+	msg := app.Message{MessageBody: []byte(messageBody)}
+	if len(messageAttributes) > 0 {
+		oldStyleMessageAttributes := convertToOldMessageAttributeValueStructure(messageAttributes)
+		msg.MessageAttributes = oldStyleMessageAttributes
+		msg.MD5OfMessageAttributes = common.HashAttributes(oldStyleMessageAttributes)
+	}
+	msg.MD5OfMessageBody = common.GetMD5Hash(messageBody)
+	msg.Uuid, _ = common.NewUUID()
+	msg.GroupID = messageGroupID
+	msg.DeduplicationID = messageDeduplicationID
+	msg.SentTime = time.Now()
+	msg.DelaySecs = delaySecs
+
+	app.SyncQueues.Lock()
+	fifoSeqNumber := ""
+	if app.SyncQueues.Queues[queueName].IsFIFO {
+		fifoSeqNumber = app.SyncQueues.Queues[queueName].NextSequenceNumber(messageGroupID)
+	}
+
+	if !app.SyncQueues.Queues[queueName].IsDuplicate(messageDeduplicationID) {
+		app.SyncQueues.Queues[queueName].Messages = append(app.SyncQueues.Queues[queueName].Messages, msg)
+	} else {
+		log.Debugf("Message with deduplicationId [%s] in queue [%s] is duplicate ", messageDeduplicationID, queueName)
+	}
+
+	app.SyncQueues.Queues[queueName].InitDuplicatation(messageDeduplicationID)
+	app.SyncQueues.Unlock()
+	log.Infof("%s: Queue: %s, Message: %s\n", time.Now().Format("2006-01-02 15:04:05"), queueName, msg.MessageBody)
+
+	respStruct := models.SendMessageResponse{
+		Xmlns: "http://queue.amazonaws.com/doc/2012-11-05/",
+		Result: models.SendMessageResult{
+			MD5OfMessageAttributes: msg.MD5OfMessageAttributes,
+			MD5OfMessageBody:       msg.MD5OfMessageBody,
+			MessageId:              msg.Uuid,
+			SequenceNumber:         fifoSeqNumber,
+		},
+		Metadata: app.ResponseMetadata{
+			RequestId: "00000000-0000-0000-0000-000000000000",
+		},
+	}
+
+	return http.StatusOK, respStruct
+}
+
+// TODO:
+// Refactor internal model for MessageAttribute between SendMessage and ReceiveMessage
+// from app.MessageAttributeValue(old) to models.MessageAttributeValue(new) and remove this temporary function.
+func convertToOldMessageAttributeValueStructure(newValues map[string]models.MessageAttributeValue) map[string]app.MessageAttributeValue {
+	attributes := make(map[string]app.MessageAttributeValue)
+
+	for name, entry := range newValues {
+		// StringListValue and BinaryListValue is currently not implemented
+		// Please refer app/gosqs/message_attributes.go
+		value := ""
+		valueKey := ""
+		if entry.StringValue != "" {
+			value = entry.StringValue
+			valueKey = "StringValue"
+		} else if entry.BinaryValue != "" {
+			value = entry.BinaryValue
+			valueKey = "BinaryValue"
+		}
+		attributes[name] = app.MessageAttributeValue{
+			Name:     name,
+			DataType: entry.DataType,
+			Value:    value,
+			ValueKey: valueKey,
+		}
+	}
+
+	return attributes
+}

--- a/app/gosqs/send_message_test.go
+++ b/app/gosqs/send_message_test.go
@@ -1,0 +1,219 @@
+package gosqs
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/Admiral-Piett/goaws/app"
+	"github.com/Admiral-Piett/goaws/app/fixtures"
+	"github.com/Admiral-Piett/goaws/app/interfaces"
+	"github.com/Admiral-Piett/goaws/app/models"
+	"github.com/Admiral-Piett/goaws/app/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSendMessageV1_Success(t *testing.T) {
+	app.CurrentEnvironment = fixtures.LOCAL_ENVIRONMENT
+	defer func() {
+		utils.ResetApp()
+		utils.REQUEST_TRANSFORMER = utils.TransformRequest
+	}()
+
+	sendMessageRequest_success := models.SendMessageRequest{
+		QueueUrl:    "http://localhost:4200/new-queue-1",
+		MessageBody: "Test Message",
+	}
+	utils.REQUEST_TRANSFORMER = func(resultingStruct interfaces.AbstractRequestBody, req *http.Request) (success bool) {
+		v := resultingStruct.(*models.SendMessageRequest)
+		*v = sendMessageRequest_success
+		return true
+	}
+
+	q := &app.Queue{
+		Name:               "new-queue-1",
+		MaximumMessageSize: 1024,
+	}
+	app.SyncQueues.Queues["new-queue-1"] = q
+
+	_, r := utils.GenerateRequestInfo("POST", "/", nil, true)
+	status, response := SendMessageV1(r)
+
+	// Check the queue
+	assert.Equal(t, 1, len(q.Messages))
+	msg := q.Messages[0]
+	assert.Equal(t, "Test Message", string(msg.MessageBody))
+
+	// Check the response
+	assert.Equal(t, http.StatusOK, status)
+	sendMessageResponse, ok := response.(models.SendMessageResponse)
+	assert.True(t, ok)
+	assert.NotEmpty(t, sendMessageResponse.Result.MD5OfMessageBody)
+	// No FIFO Sequence
+	assert.Empty(t, sendMessageResponse.Result.SequenceNumber)
+}
+
+func TestSendMessageV1_Success_FIFOQueue(t *testing.T) {
+	app.CurrentEnvironment = fixtures.LOCAL_ENVIRONMENT
+	defer func() {
+		utils.ResetApp()
+		utils.REQUEST_TRANSFORMER = utils.TransformRequest
+	}()
+
+	sendMessageRequest_success := models.SendMessageRequest{
+		QueueUrl:    "http://localhost:4200/new-queue-1",
+		MessageBody: "Test Message",
+	}
+	utils.REQUEST_TRANSFORMER = func(resultingStruct interfaces.AbstractRequestBody, req *http.Request) (success bool) {
+		v := resultingStruct.(*models.SendMessageRequest)
+		*v = sendMessageRequest_success
+		return true
+	}
+
+	q := &app.Queue{
+		Name:               "new-queue-1",
+		MaximumMessageSize: 1024,
+		IsFIFO:             true,
+	}
+	app.SyncQueues.Queues["new-queue-1"] = q
+
+	_, r := utils.GenerateRequestInfo("POST", "/", nil, true)
+	status, response := SendMessageV1(r)
+
+	// Check the queue
+	assert.Equal(t, 1, len(q.Messages))
+	msg := q.Messages[0]
+	assert.Equal(t, "Test Message", string(msg.MessageBody))
+
+	// Check the response
+	assert.Equal(t, http.StatusOK, status)
+	sendMessageResponse, ok := response.(models.SendMessageResponse)
+	assert.True(t, ok)
+	assert.NotEmpty(t, sendMessageResponse.Result.MD5OfMessageBody)
+	// Should have FIFO Sequence
+	assert.NotEmpty(t, sendMessageResponse.Result.SequenceNumber)
+}
+
+func TestSendMessageV1_Success_Deduplication(t *testing.T) {
+	app.CurrentEnvironment = fixtures.LOCAL_ENVIRONMENT
+	defer func() {
+		utils.ResetApp()
+		utils.REQUEST_TRANSFORMER = utils.TransformRequest
+	}()
+
+	sendMessageRequest_success := models.SendMessageRequest{
+		QueueUrl:               "http://localhost:4200/new-queue-1",
+		MessageBody:            "Test Message",
+		MessageDeduplicationId: "1",
+	}
+	utils.REQUEST_TRANSFORMER = func(resultingStruct interfaces.AbstractRequestBody, req *http.Request) (success bool) {
+		v := resultingStruct.(*models.SendMessageRequest)
+		*v = sendMessageRequest_success
+		return true
+	}
+
+	q := &app.Queue{
+		Name:               "new-queue-1",
+		MaximumMessageSize: 1024,
+		IsFIFO:             true,
+		EnableDuplicates:   true,
+		Duplicates:         make(map[string]time.Time),
+	}
+	app.SyncQueues.Queues["new-queue-1"] = q
+
+	_, r := utils.GenerateRequestInfo("POST", "/", nil, true)
+	status, _ := SendMessageV1(r)
+
+	// Check the queue
+	assert.Equal(t, 1, len(q.Messages))
+	// Check the response
+	assert.Equal(t, http.StatusOK, status)
+
+	// Send the same message (have DeduplicationId)
+	status, _ = SendMessageV1(r)
+	// Response is "success"
+	assert.Equal(t, http.StatusOK, status)
+	// Only 1 message should be in the queue
+	assert.Equal(t, 1, len(q.Messages))
+}
+
+func TestSendMessageV1_request_transformer_error(t *testing.T) {
+	app.CurrentEnvironment = fixtures.LOCAL_ENVIRONMENT
+	defer func() {
+		utils.ResetApp()
+		utils.REQUEST_TRANSFORMER = utils.TransformRequest
+	}()
+
+	utils.REQUEST_TRANSFORMER = func(resultingStruct interfaces.AbstractRequestBody, req *http.Request) (success bool) {
+		return false
+	}
+
+	_, r := utils.GenerateRequestInfo("POST", "/", nil, true)
+	code, _ := SendMessageV1(r)
+
+	assert.Equal(t, http.StatusBadRequest, code)
+}
+
+func TestSendMessageV1_MaximumMessageSize_MessageTooBig(t *testing.T) {
+	app.CurrentEnvironment = fixtures.LOCAL_ENVIRONMENT
+	defer func() {
+		utils.ResetApp()
+		utils.REQUEST_TRANSFORMER = utils.TransformRequest
+	}()
+
+	sendMessageRequest_success := models.SendMessageRequest{
+		QueueUrl:    "http://localhost:4200/new-queue-1",
+		MessageBody: "Test Message",
+	}
+	utils.REQUEST_TRANSFORMER = func(resultingStruct interfaces.AbstractRequestBody, req *http.Request) (success bool) {
+		v := resultingStruct.(*models.SendMessageRequest)
+		*v = sendMessageRequest_success
+		return true
+	}
+
+	q := &app.Queue{
+		Name:               "new-queue-1",
+		MaximumMessageSize: 1,
+	}
+	app.SyncQueues.Queues["new-queue-1"] = q
+
+	_, r := utils.GenerateRequestInfo("POST", "/", nil, true)
+	status, response := SendMessageV1(r)
+
+	// Check the response
+	assert.Equal(t, http.StatusBadRequest, status)
+	errorResponse, ok := response.(models.ErrorResponse)
+	assert.True(t, ok)
+	assert.Equal(t, "MessageTooBig", errorResponse.Result.Type)
+}
+
+func TestSendMessageV1_POST_QueueNonExistant(t *testing.T) {
+	app.CurrentEnvironment = fixtures.LOCAL_ENVIRONMENT
+	defer func() {
+		utils.ResetApp()
+		utils.REQUEST_TRANSFORMER = utils.TransformRequest
+	}()
+
+	sendMessageRequest_success := models.SendMessageRequest{
+		QueueUrl:    "http://localhost:4200/new-queue-1",
+		MessageBody: "Test Message",
+	}
+	utils.REQUEST_TRANSFORMER = func(resultingStruct interfaces.AbstractRequestBody, req *http.Request) (success bool) {
+		v := resultingStruct.(*models.SendMessageRequest)
+		*v = sendMessageRequest_success
+		return true
+	}
+
+	// No test queue is added to app.SyncQueues
+
+	_, r := utils.GenerateRequestInfo("POST", "/", nil, true)
+	status, response := SendMessageV1(r)
+
+	// Check the status code is what we expect.
+	assert.Equal(t, http.StatusBadRequest, status)
+
+	// Check the response body is what we expect.
+	errorResponse, ok := response.(models.ErrorResponse)
+	assert.True(t, ok)
+	assert.Equal(t, "Not Found", errorResponse.Result.Type)
+}

--- a/app/models/models_test.go
+++ b/app/models/models_test.go
@@ -283,3 +283,39 @@ func TestGetQueueAttributesRequest_SetAttributesFromForm_skips_invalid_key_seque
 	assert.Equal(t, 1, len(lqr.AttributeNames))
 	assert.Contains(t, lqr.AttributeNames, "attribute-1")
 }
+
+func TestSendMessageRequest_SetAttributesFromForm_success(t *testing.T) {
+	form := url.Values{}
+	form.Add("MessageAttribute.1.Name", "Attr1")
+	form.Add("MessageAttribute.1.Value.DataType", "String")
+	form.Add("MessageAttribute.1.Value.StringValue", "Value1")
+	form.Add("MessageAttribute.2.Name", "Attr2")
+	form.Add("MessageAttribute.2.Value.DataType", "Binary")
+	form.Add("MessageAttribute.2.Value.BinaryValue", "VmFsdWUy")
+	form.Add("MessageAttribute.3.Name", "")
+	form.Add("MessageAttribute.3.Value.DataType", "String")
+	form.Add("MessageAttribute.3.Value.StringValue", "Value")
+	form.Add("MessageAttribute.4.Name", "Attr4")
+	form.Add("MessageAttribute.4.Value.DataType", "")
+	form.Add("MessageAttribute.4.Value.StringValue", "Value4")
+
+	r := &SendMessageRequest{
+		MessageAttributes:       make(map[string]MessageAttributeValue),
+		MessageSystemAttributes: make(map[string]MessageAttributeValue),
+	}
+	r.SetAttributesFromForm(form)
+
+	assert.Equal(t, 2, len(r.MessageAttributes))
+
+	assert.NotNil(t, r.MessageAttributes["Attr1"])
+	attr1 := r.MessageAttributes["Attr1"]
+	assert.Equal(t, "String", attr1.DataType)
+	assert.Equal(t, "Value1", attr1.StringValue)
+	assert.Equal(t, "", attr1.BinaryValue)
+
+	assert.NotNil(t, r.MessageAttributes["Attr2"])
+	attr2 := r.MessageAttributes["Attr2"]
+	assert.Equal(t, "Binary", attr2.DataType)
+	assert.Equal(t, "", attr2.StringValue)
+	assert.Equal(t, "VmFsdWUy", attr2.BinaryValue)
+}

--- a/app/models/responses.go
+++ b/app/models/responses.go
@@ -93,3 +93,25 @@ func (r GetQueueAttributesResponse) GetResult() interface{} {
 func (r GetQueueAttributesResponse) GetRequestId() string {
 	return r.Metadata.RequestId
 }
+
+/*** Send Message Response */
+type SendMessageResult struct {
+	MD5OfMessageAttributes string `xml:"MD5OfMessageAttributes"`
+	MD5OfMessageBody       string `xml:"MD5OfMessageBody"`
+	MessageId              string `xml:"MessageId"`
+	SequenceNumber         string `xml:"SequenceNumber"`
+}
+
+type SendMessageResponse struct {
+	Xmlns    string               `xml:"xmlns,attr"`
+	Result   SendMessageResult    `xml:"SendMessageResult"`
+	Metadata app.ResponseMetadata `xml:"ResponseMetadata"`
+}
+
+func (r SendMessageResponse) GetResult() interface{} {
+	return r.Result
+}
+
+func (r SendMessageResponse) GetRequestId() string {
+	return r.Metadata.RequestId
+}

--- a/app/router/router.go
+++ b/app/router/router.go
@@ -63,12 +63,12 @@ var routingTableV1 = map[string]func(r *http.Request) (int, interfaces.AbstractR
 	"CreateQueue":        sqs.CreateQueueV1,
 	"ListQueues":         sqs.ListQueuesV1,
 	"GetQueueAttributes": sqs.GetQueueAttributesV1,
+	"SendMessage":        sqs.SendMessageV1,
 }
 
 var routingTable = map[string]http.HandlerFunc{
 	// SQS
 	"SetQueueAttributes":      sqs.SetQueueAttributes,
-	"SendMessage":             sqs.SendMessage,
 	"SendMessageBatch":        sqs.SendMessageBatch,
 	"ReceiveMessage":          sqs.ReceiveMessage,
 	"DeleteMessage":           sqs.DeleteMessage,

--- a/app/router/router_test.go
+++ b/app/router/router_test.go
@@ -263,11 +263,11 @@ func TestActionHandler_v0_xml(t *testing.T) {
 			"CreateQueue":        sqs.CreateQueueV1,
 			"ListQueues":         sqs.ListQueuesV1,
 			"GetQueueAttributes": sqs.GetQueueAttributesV1,
+			"SendMessage":        sqs.SendMessageV1,
 		}
 		routingTable = map[string]http.HandlerFunc{
 			// SQS
 			"SetQueueAttributes":      sqs.SetQueueAttributes,
-			"SendMessage":             sqs.SendMessage,
 			"SendMessageBatch":        sqs.SendMessageBatch,
 			"ReceiveMessage":          sqs.ReceiveMessage,
 			"DeleteMessage":           sqs.DeleteMessage,

--- a/app/sqs_messages.go
+++ b/app/sqs_messages.go
@@ -1,18 +1,14 @@
 package app
 
-/*** Send Message Response */
-
-type SendMessageResult struct {
-	MD5OfMessageAttributes string `xml:"MD5OfMessageAttributes"`
-	MD5OfMessageBody       string `xml:"MD5OfMessageBody"`
-	MessageId              string `xml:"MessageId"`
-	SequenceNumber         string `xml:"SequenceNumber"`
+/*** List Queues Response */
+type ListQueuesResult struct {
+	QueueUrl []string `xml:"QueueUrl"`
 }
 
-type SendMessageResponse struct {
-	Xmlns    string            `xml:"xmlns,attr"`
-	Result   SendMessageResult `xml:"SendMessageResult"`
-	Metadata ResponseMetadata  `xml:"ResponseMetadata"`
+type ListQueuesResponse struct {
+	Xmlns    string           `xml:"xmlns,attr"`
+	Result   ListQueuesResult `xml:"ListQueuesResult"`
+	Metadata ResponseMetadata `xml:"ResponseMetadata"`
 }
 
 /*** Receive Message Response */

--- a/smoke_tests/sqs_send_message_test.go
+++ b/smoke_tests/sqs_send_message_test.go
@@ -1,0 +1,373 @@
+package smoke_tests
+
+import (
+	"context"
+	"encoding/xml"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/Admiral-Piett/goaws/app"
+	af "github.com/Admiral-Piett/goaws/app/fixtures"
+	"github.com/Admiral-Piett/goaws/app/models"
+	"github.com/Admiral-Piett/goaws/app/utils"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	sqstypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
+	"github.com/gavv/httpexpect/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_SendMessageV1_json_no_attributes(t *testing.T) {
+	server := generateServer()
+	defer func() {
+		server.Close()
+		utils.ResetResources()
+	}()
+
+	sdkConfig, _ := config.LoadDefaultConfig(context.TODO())
+	sdkConfig.BaseEndpoint = aws.String(server.URL)
+	sqsClient := sqs.NewFromConfig(sdkConfig)
+	sdkResponse, _ := sqsClient.CreateQueue(context.TODO(), &sqs.CreateQueueInput{
+		QueueName: &af.QueueName,
+	})
+	targetQueueUrl := sdkResponse.QueueUrl
+
+	// Assert no messages in the queue before sending message
+	getQueueAttributeOutput, _ := sqsClient.GetQueueAttributes(context.TODO(), &sqs.GetQueueAttributesInput{
+		QueueUrl: targetQueueUrl,
+	})
+	assert.Equal(t, "0", getQueueAttributeOutput.Attributes["ApproximateNumberOfMessages"])
+
+	// Target test: send a message
+	targetMessageBody := "Test_SendMessageV1_json_no_attributes"
+	sendMessageOutput, _ := sqsClient.SendMessage(context.TODO(), &sqs.SendMessageInput{
+		QueueUrl:    targetQueueUrl,
+		MessageBody: &targetMessageBody,
+	})
+	assert.NotNil(t, sendMessageOutput.MessageId)
+
+	// Assert 1 message in the queue
+	getQueueAttributeOutput, _ = sqsClient.GetQueueAttributes(context.TODO(), &sqs.GetQueueAttributesInput{
+		QueueUrl: targetQueueUrl,
+	})
+	assert.Equal(t, "1", getQueueAttributeOutput.Attributes["ApproximateNumberOfMessages"])
+
+	// Receive message and check attribute
+	receiveMessageBodyXML := struct {
+		Action   string `xml:"Action"`
+		Version  string `xml:"Version"`
+		QueueUrl string `xml:"QueueUrl"`
+	}{
+		Action:   "ReceiveMessage",
+		Version:  "2012-11-05",
+		QueueUrl: *targetQueueUrl,
+	}
+	e := httpexpect.Default(t, server.URL)
+	r := e.POST("/").
+		WithForm(receiveMessageBodyXML).
+		Expect().
+		Status(http.StatusOK).
+		Body().Raw()
+	r3 := app.ReceiveMessageResponse{}
+	xml.Unmarshal([]byte(r), &r3)
+	message := r3.Result.Message[0]
+	assert.Equal(t, targetMessageBody, string(message.Body))
+	assert.Equal(t, 0, len(message.MessageAttributes))
+}
+
+func Test_SendMessageV1_json_with_attributes(t *testing.T) {
+	server := generateServer()
+	defer func() {
+		server.Close()
+		utils.ResetResources()
+	}()
+
+	sdkConfig, _ := config.LoadDefaultConfig(context.TODO())
+	sdkConfig.BaseEndpoint = aws.String(server.URL)
+	sqsClient := sqs.NewFromConfig(sdkConfig)
+	sdkResponse, _ := sqsClient.CreateQueue(context.TODO(), &sqs.CreateQueueInput{
+		QueueName: &af.QueueName,
+	})
+	targetQueueUrl := sdkResponse.QueueUrl
+
+	// Target test: send a message
+	targetMessageBody := "Test_SendMessageV1_json_with_attributes"
+	attr1_dataType := "String"
+	attr1_value := "attr1_value"
+	attr2_dataType := "Number"
+	attr2_value := "2"
+	attr3_dataType := "Binary"
+	attr3_value := []byte("attr3_value")
+	sendMessageOutput, _ := sqsClient.SendMessage(context.TODO(), &sqs.SendMessageInput{
+		QueueUrl:     targetQueueUrl,
+		MessageBody:  &targetMessageBody,
+		DelaySeconds: 1,
+		MessageAttributes: map[string]sqstypes.MessageAttributeValue{
+			"attr1": {
+				DataType:    &attr1_dataType,
+				StringValue: &attr1_value,
+			},
+			"attr2": {
+				DataType:    &attr2_dataType,
+				StringValue: &attr2_value,
+			},
+			"attr3": {
+				DataType:    &attr3_dataType,
+				BinaryValue: attr3_value,
+			},
+		},
+	})
+	assert.NotNil(t, sendMessageOutput.MessageId)
+
+	// Wait for DelaySecond
+	time.Sleep(1 * time.Second)
+
+	// Assert 1 message in the queue
+	getQueueAttributeOutput, _ := sqsClient.GetQueueAttributes(context.TODO(), &sqs.GetQueueAttributesInput{
+		QueueUrl: targetQueueUrl,
+	})
+	assert.Equal(t, "1", getQueueAttributeOutput.Attributes["ApproximateNumberOfMessages"])
+
+	// Receive message and check attribute
+	receiveMessageBodyXML := struct {
+		Action   string `xml:"Action"`
+		Version  string `xml:"Version"`
+		QueueUrl string `xml:"QueueUrl"`
+	}{
+		Action:   "ReceiveMessage",
+		Version:  "2012-11-05",
+		QueueUrl: *targetQueueUrl,
+	}
+	e := httpexpect.Default(t, server.URL)
+	r := e.POST("/").
+		WithForm(receiveMessageBodyXML).
+		Expect().
+		Status(http.StatusOK).
+		Body().Raw()
+	r3 := app.ReceiveMessageResponse{}
+	xml.Unmarshal([]byte(r), &r3)
+	message := r3.Result.Message[0]
+	assert.Equal(t, targetMessageBody, string(message.Body))
+	assert.Equal(t, 3, len(message.MessageAttributes))
+	var attr1, attr2, attr3 app.ResultMessageAttribute
+	for _, attr := range message.MessageAttributes {
+		if attr.Name == "attr1" {
+			attr1 = *attr
+		} else if attr.Name == "attr2" {
+			attr2 = *attr
+		} else if attr.Name == "attr3" {
+			attr3 = *attr
+		}
+	}
+	assert.Equal(t, "attr1", attr1.Name)
+	assert.Equal(t, "String", attr1.Value.DataType)
+	assert.Equal(t, "attr1_value", attr1.Value.StringValue)
+	assert.Equal(t, "attr2", attr2.Name)
+	assert.Equal(t, "Number", attr2.Value.DataType)
+	assert.Equal(t, "2", attr2.Value.StringValue)
+	assert.Equal(t, "attr3", attr3.Name)
+	assert.Equal(t, "Binary", attr3.Value.DataType)
+	assert.Equal(t, "YXR0cjNfdmFsdWU=", attr3.Value.BinaryValue) // base64 encoded "attr3_value"
+}
+
+func Test_SendMessageV1_json_MaximumMessageSize_TooBig(t *testing.T) {
+	server := generateServer()
+	defer func() {
+		server.Close()
+		utils.ResetResources()
+	}()
+
+	sdkConfig, _ := config.LoadDefaultConfig(context.TODO())
+	sdkConfig.BaseEndpoint = aws.String(server.URL)
+	sqsClient := sqs.NewFromConfig(sdkConfig)
+	sdkResponse, _ := sqsClient.CreateQueue(context.TODO(), &sqs.CreateQueueInput{
+		QueueName: &af.QueueName,
+		Attributes: map[string]string{
+			"MaximumMessageSize": "1",
+		},
+	})
+	targetQueueUrl := sdkResponse.QueueUrl
+
+	// Target test: send a message that is bigger than MaximumMessageSize
+	targetMessageBody := "Test_SendMessageV1_json_no_attributes"
+	sendMessageOutput, err := sqsClient.SendMessage(context.TODO(), &sqs.SendMessageInput{
+		QueueUrl:    targetQueueUrl,
+		MessageBody: &targetMessageBody,
+	})
+	assert.Contains(t, err.Error(), "400")
+	assert.Contains(t, err.Error(), "InvalidParameterValue")
+	assert.Nil(t, sendMessageOutput)
+}
+
+func Test_SendMessageV1_json_QueueNotExistant(t *testing.T) {
+	server := generateServer()
+	defer func() {
+		server.Close()
+		utils.ResetResources()
+	}()
+
+	sdkConfig, _ := config.LoadDefaultConfig(context.TODO())
+	sdkConfig.BaseEndpoint = aws.String(server.URL)
+	sqsClient := sqs.NewFromConfig(sdkConfig)
+
+	// Target test: send a message to a queue that is not exist
+	queueUrl := "http://region.host:port/accountID/not-existant-queue"
+	targetMessageBody := "Test_SendMessageV1_json_no_attributes"
+	sendMessageOutput, err := sqsClient.SendMessage(context.TODO(), &sqs.SendMessageInput{
+		QueueUrl:    &queueUrl,
+		MessageBody: &targetMessageBody,
+	})
+	assert.Contains(t, err.Error(), "400")
+	assert.Contains(t, err.Error(), "AWS.SimpleQueueService.NonExistentQueue")
+	assert.Nil(t, sendMessageOutput)
+}
+
+func Test_SendMessageV1_xml_no_attributes(t *testing.T) {
+	server := generateServer()
+	defer func() {
+		server.Close()
+		utils.ResetResources()
+	}()
+
+	sdkConfig, _ := config.LoadDefaultConfig(context.TODO())
+	sdkConfig.BaseEndpoint = aws.String(server.URL)
+	sqsClient := sqs.NewFromConfig(sdkConfig)
+	sdkResponse, _ := sqsClient.CreateQueue(context.TODO(), &sqs.CreateQueueInput{
+		QueueName: &af.QueueName,
+	})
+	targetQueueUrl := sdkResponse.QueueUrl
+
+	// Assert no messages in the queue before sending message
+	getQueueAttributeOutput, _ := sqsClient.GetQueueAttributes(context.TODO(), &sqs.GetQueueAttributesInput{
+		QueueUrl: targetQueueUrl,
+	})
+	assert.Equal(t, "0", getQueueAttributeOutput.Attributes["ApproximateNumberOfMessages"])
+
+	// Target test: send a message
+	sendMessageXML := struct {
+		Action      string `xml:"Action"`
+		Version     string `xml:"Version"`
+		QueueUrl    string `xml:"QueueUrl"`
+		MessageBody string `xml:"MessageBody"`
+	}{
+		Action:      "SendMessage",
+		Version:     "2012-11-05",
+		QueueUrl:    *targetQueueUrl,
+		MessageBody: "Test Message",
+	}
+	e := httpexpect.Default(t, server.URL)
+	r := e.POST("/").
+		WithForm(sendMessageXML).
+		Expect().
+		Status(http.StatusOK).
+		Body().Raw()
+	r3 := models.SendMessageResult{}
+	xml.Unmarshal([]byte(r), &r3)
+	assert.NotNil(t, r3.MessageId)
+
+	// Assert 1 message in the queue
+	getQueueAttributeOutput, _ = sqsClient.GetQueueAttributes(context.TODO(), &sqs.GetQueueAttributesInput{
+		QueueUrl: targetQueueUrl,
+	})
+	assert.Equal(t, "1", getQueueAttributeOutput.Attributes["ApproximateNumberOfMessages"])
+}
+
+func Test_SendMessageV1_xml_with_attributes(t *testing.T) {
+	server := generateServer()
+	defer func() {
+		server.Close()
+		utils.ResetResources()
+	}()
+
+	sdkConfig, _ := config.LoadDefaultConfig(context.TODO())
+	sdkConfig.BaseEndpoint = aws.String(server.URL)
+	sqsClient := sqs.NewFromConfig(sdkConfig)
+	sdkResponse, _ := sqsClient.CreateQueue(context.TODO(), &sqs.CreateQueueInput{
+		QueueName: &af.QueueName,
+	})
+	targetQueueUrl := sdkResponse.QueueUrl
+
+	// Assert no messages in the queue before sending message
+	getQueueAttributeOutput, _ := sqsClient.GetQueueAttributes(context.TODO(), &sqs.GetQueueAttributesInput{
+		QueueUrl: targetQueueUrl,
+	})
+	assert.Equal(t, "0", getQueueAttributeOutput.Attributes["ApproximateNumberOfMessages"])
+
+	// Target test: send a message
+	sendMessageXML := struct {
+		Action       string `xml:"Action"`
+		Version      string `xml:"Version"`
+		QueueUrl     string `xml:"QueueUrl"`
+		MessageBody  string `xml:"MessageBody"`
+		DelaySeconds string `xml:"DelaySeconds"`
+	}{
+		Action:       "SendMessage",
+		Version:      "2012-11-05",
+		QueueUrl:     *targetQueueUrl,
+		MessageBody:  "Test Message",
+		DelaySeconds: "1",
+	}
+	e := httpexpect.Default(t, server.URL)
+	r := e.POST("/").
+		WithForm(sendMessageXML).
+		WithFormField("MessageAttribute.1.Name", "attr1").
+		WithFormField("MessageAttribute.1.Value.DataType", "String").
+		WithFormField("MessageAttribute.1.Value.StringValue", "attr1_value").
+		WithFormField("MessageAttribute.2.Name", "attr2").
+		WithFormField("MessageAttribute.2.Value.DataType", "Number").
+		WithFormField("MessageAttribute.2.Value.StringValue", "2").
+		WithFormField("MessageAttribute.3.Name", "attr3").
+		WithFormField("MessageAttribute.3.Value.DataType", "Binary").
+		WithFormField("MessageAttribute.3.Value.BinaryValue", "YXR0cjNfdmFsdWU=").
+		Expect().
+		Status(http.StatusOK).
+		Body().Raw()
+	r3 := models.SendMessageResult{}
+	xml.Unmarshal([]byte(r), &r3)
+	assert.NotNil(t, r3.MessageId)
+
+	// Wait for DelaySecond
+	time.Sleep(1 * time.Second)
+
+	// Receive message and check attribute
+	receiveMessageBodyXML := struct {
+		Action   string `xml:"Action"`
+		Version  string `xml:"Version"`
+		QueueUrl string `xml:"QueueUrl"`
+	}{
+		Action:   "ReceiveMessage",
+		Version:  "2012-11-05",
+		QueueUrl: *targetQueueUrl,
+	}
+	r = e.POST("/").
+		WithForm(receiveMessageBodyXML).
+		Expect().
+		Status(http.StatusOK).
+		Body().Raw()
+	r4 := app.ReceiveMessageResponse{}
+	xml.Unmarshal([]byte(r), &r4)
+	message := r4.Result.Message[0]
+	assert.Equal(t, "Test Message", string(message.Body))
+	assert.Equal(t, 3, len(message.MessageAttributes))
+	var attr1, attr2, attr3 app.ResultMessageAttribute
+	for _, attr := range message.MessageAttributes {
+		if attr.Name == "attr1" {
+			attr1 = *attr
+		} else if attr.Name == "attr2" {
+			attr2 = *attr
+		} else if attr.Name == "attr3" {
+			attr3 = *attr
+		}
+	}
+	assert.Equal(t, "attr1", attr1.Name)
+	assert.Equal(t, "String", attr1.Value.DataType)
+	assert.Equal(t, "attr1_value", attr1.Value.StringValue)
+	assert.Equal(t, "attr2", attr2.Name)
+	assert.Equal(t, "Number", attr2.Value.DataType)
+	assert.Equal(t, "2", attr2.Value.StringValue)
+	assert.Equal(t, "attr3", attr3.Name)
+	assert.Equal(t, "Binary", attr3.Value.DataType)
+	assert.Equal(t, "YXR0cjNfdmFsdWU=", attr3.Value.BinaryValue) // base64 encoded "attr3_value"
+}


### PR DESCRIPTION
- [x] Create a model for your new Request struct
    - a. Implement <NewStruct>.SetAttributesFromForm - even if it just returns without doing anything.
    - b. You may also need to handle UnmarshalJSON for any nested request attributes/objects.
- [x] Create a RequestFunctionV1 function
- [x] Swap the reference in the routing table to the new V1 routing table
- [x] Copy the code from the old function
- [x] Call utils.REQUEST_TRANSFORMER with your new struct
- [x] Update fetches from the request Form to look at the new struct
- [x] Make the new V1 function return a status and response struct
- [x] Update any references to createErrorResponse to use createErrorResponseV1
- [x] Delete old/non-V1 function
- [x] Update/Create/Remove unit tests
- [x] Smoke Test with the SDK
- [x] Add automated tests in smoke_tests/... (use the v2 SDK as much as possible)