### PR TITLE
chore(release): build multi-arch docker image with same suffix

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -44,12 +44,9 @@ dockers:
   - goos: linux
     goarch: amd64
     dockerfile: goreleaser.dockerfile
+    use: buildx
     image_templates:
-      - "admiralpiett/goaws"
-      - "admiralpiett/goaws:{{ .Tag }}"
       - "admiralpiett/goaws:{{ .Tag }}-amd64"
-      - "admiralpiett/goaws:latest-amd64"
-      - "admiralpiett/goaws:latest"
     extra_files:
       - app/conf/goaws.yaml
     build_flag_templates:
@@ -57,13 +54,23 @@ dockers:
   - goos: linux
     goarch: arm64
     dockerfile: goreleaser.dockerfile
+    use: buildx
     image_templates:
       - "admiralpiett/goaws:{{ .Tag }}-arm64"
-      - "admiralpiett/goaws:latest-arm64"
     extra_files:
       - app/conf/goaws.yaml
     build_flag_templates:
       - "--platform=linux/arm64"
+
+docker_manifests:
+- name_template: admiralpiett/goaws:{{ .Tag }}
+  image_templates:
+  - admiralpiett/goaws:{{ .Tag }}-amd64
+  - admiralpiett/goaws:{{ .Tag }}-arm64
+- name_template: admiralpiett/goaws:latest
+  image_templates:
+  - admiralpiett/goaws:{{ .Tag }}-amd64
+  - admiralpiett/goaws:{{ .Tag }}-arm64
 
 archives:
   - id: archive_names


### PR DESCRIPTION
While trying to migrate workloads from amd64 to arm64, having a single tag for both architectures makes the transition easier.

References:
- https://goreleaser.com/cookbooks/multi-platform-docker-images/#creating-multi-platform-docker-images-with-goreleaser
- https://carlosbecker.com/posts/multi-platform-docker-images-goreleaser-gh-actions/