### PR TITLE
Send message to DLQ after correct number of attempts

### DIFF
--- a/app/gosqs/change_message_visibility.go
+++ b/app/gosqs/change_message_visibility.go
@@ -56,10 +56,9 @@ func ChangeMessageVisibilityV1(req *http.Request) (int, interfaces.AbstractRespo
 				msgs[i].Retry++
 				if queue.MaxReceiveCount > 0 &&
 					queue.DeadLetterQueue != nil &&
-					msgs[i].Retry > queue.MaxReceiveCount {
+					msgs[i].Retry >= queue.MaxReceiveCount {
 					queue.DeadLetterQueue.Messages = append(queue.DeadLetterQueue.Messages, msgs[i])
 					queue.Messages = append(queue.Messages[:i], queue.Messages[i+1:]...)
-					i++
 				}
 			} else {
 				msgs[i].VisibilityTimeout = time.Now().Add(time.Duration(visibilityTimeout) * time.Second)

--- a/app/gosqs/gosqs.go
+++ b/app/gosqs/gosqs.go
@@ -43,10 +43,10 @@ func PeriodicTasks(d time.Duration, quit <-chan struct{}) {
 							msg.Retry++
 							if queue.MaxReceiveCount > 0 &&
 								queue.DeadLetterQueue != nil &&
-								msg.Retry > queue.MaxReceiveCount {
+								msg.Retry >= queue.MaxReceiveCount {
 								queue.DeadLetterQueue.Messages = append(queue.DeadLetterQueue.Messages, *msg)
 								queue.Messages = append(queue.Messages[:i], queue.Messages[i+1:]...)
-								i++
+								i--
 							}
 						}
 					}


### PR DESCRIPTION
I just noticed you released the JSON API update, congratulations and thanks for your time and effort!

I was trying it out today and everything seems to work as expected, except for DLQ MaxReceiveCounts. As described in #263 in AWS the attribute describes the number of attempts before sending a message to the DLQ, not the number of retries.

There was also a small error when iterating over the messages where when a message that got sent to the DLQ would skip the next message in that queue for the timeout check in that iteration.

Closes: #263