### PR TITLE
[Bugfix] Add base64 decode on json mashaller

### DIFF
--- a/app/gosqs/message_attributes.go
+++ b/app/gosqs/message_attributes.go
@@ -43,7 +43,7 @@ func extractMessageAttributes(req *http.Request, prefix string) map[string]app.M
 	return attributes
 }
 
-func getMessageAttributeResult(a *app.MessageAttributeValue) *models.ResultMessageAttribute {
+func getMessageAttributeResult(a app.MessageAttributeValue) *models.ResultMessageAttribute {
 	v := &models.ResultMessageAttributeValue{
 		DataType: a.DataType,
 	}
@@ -51,8 +51,10 @@ func getMessageAttributeResult(a *app.MessageAttributeValue) *models.ResultMessa
 	switch a.DataType {
 	case "Binary":
 		v.BinaryValue = a.Value
-	default:
-		v.StringValue = a.Value
+	case "String":
+		v.StringValue = &a.Value
+	case "Number":
+		v.StringValue = &a.Value
 	}
 
 	return &models.ResultMessageAttribute{

--- a/app/gosqs/receive_message.go
+++ b/app/gosqs/receive_message.go
@@ -144,7 +144,7 @@ func ReceiveMessageV1(req *http.Request) (int, interfaces.AbstractResponseBody) 
 func getMessageResult(m *app.Message) *models.ResultMessage {
 	msgMttrs := []*models.ResultMessageAttribute{}
 	for _, attr := range m.MessageAttributes {
-		msgMttrs = append(msgMttrs, getMessageAttributeResult(&attr))
+		msgMttrs = append(msgMttrs, getMessageAttributeResult(attr))
 	}
 
 	attrsMap := map[string]string{

--- a/app/gosqs/receive_message_test.go
+++ b/app/gosqs/receive_message_test.go
@@ -212,5 +212,5 @@ func TestReceiveMessageAttributesV1(t *testing.T) {
 	assert.Equal(t, 1, len(result.Messages[0].MessageAttributes))
 	assert.Equal(t, "TestMessageAttrName", result.Messages[0].MessageAttributes[0].Name)
 	assert.Equal(t, "String", result.Messages[0].MessageAttributes[0].Value.DataType)
-	assert.Equal(t, "TestMessageAttrValue", result.Messages[0].MessageAttributes[0].Value.StringValue)
+	assert.Equal(t, "TestMessageAttrValue", *result.Messages[0].MessageAttributes[0].Value.StringValue)
 }

--- a/app/models/models.go
+++ b/app/models/models.go
@@ -27,7 +27,7 @@ var AVAILABLE_QUEUE_ATTRIBUTES = map[string]bool{
 // TODO - reconcile this with app.MessageAttributeValue - deal with ConvertToOldMessageAttributeValueStructure
 type MessageAttributeValue struct {
 	BinaryListValues []string `json:"BinaryListValues,omitempty"` // currently unsupported by AWS
-	BinaryValue      string   `json:"BinaryValue,omitempty"`
+	BinaryValue      string   `json:"BinaryValue,omitempty"`      // base64 encoded string
 	DataType         string   `json:"DataType,omitempty"`
 	StringListValues []string `json:"StringListValues,omitempty"` // currently unsupported by AWS
 	StringValue      string   `json:"StringValue,omitempty"`

--- a/app/models/responses.go
+++ b/app/models/responses.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"encoding/base64"
 	"encoding/json"
 
 	"github.com/Admiral-Piett/goaws/app"
@@ -80,10 +81,12 @@ func (r *ResultMessage) MarshalJSON() ([]byte, error) {
 	}
 
 	for _, attr := range r.MessageAttributes {
+		// When encoding json, BinaryValue([]byte) are automatically converted to base64.
+		binary, _ := base64.StdEncoding.DecodeString(attr.Value.BinaryValue)
 		m.MessageAttributes[attr.Name] = sqstypes.MessageAttributeValue{
 			DataType:    &attr.Value.DataType,
-			StringValue: &attr.Value.StringValue,
-			BinaryValue: []byte(attr.Value.BinaryValue),
+			StringValue: attr.Value.StringValue,
+			BinaryValue: binary,
 		}
 	}
 
@@ -91,9 +94,9 @@ func (r *ResultMessage) MarshalJSON() ([]byte, error) {
 }
 
 type ResultMessageAttributeValue struct {
-	DataType    string `xml:"DataType,omitempty"`
-	StringValue string `xml:"StringValue,omitempty"`
-	BinaryValue string `xml:"BinaryValue,omitempty"`
+	DataType    string  `xml:"DataType,omitempty"`
+	StringValue *string `xml:"StringValue,omitempty"`
+	BinaryValue string  `xml:"BinaryValue,omitempty"`
 }
 
 type ResultMessageAttribute struct {

--- a/smoke_tests/sqs_send_message_batch_test.go
+++ b/smoke_tests/sqs_send_message_batch_test.go
@@ -2,6 +2,7 @@ package smoke_tests
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/xml"
 	"fmt"
 	"net/http"
@@ -253,7 +254,8 @@ func TestSendMessageBatchV1_Json_Success(t *testing.T) {
 	stringType := "String"
 	numberType := "Number"
 
-	binaryValue := "base64-encoded-value"
+	binaryValueString := "binary-value"
+	binaryValue := []byte(binaryValueString)
 	stringValue := "hogeValue"
 	numberValue := "100"
 
@@ -268,7 +270,7 @@ func TestSendMessageBatchV1_Json_Success(t *testing.T) {
 				MessageBody: &messageBody2,
 				MessageAttributes: map[string]types.MessageAttributeValue{
 					binaryAttribute: {
-						BinaryValue: []byte(binaryValue),
+						BinaryValue: binaryValue,
 						DataType:    &binaryType,
 					},
 					stringAttribute: {
@@ -318,27 +320,27 @@ func TestSendMessageBatchV1_Json_Success(t *testing.T) {
 			attr2.Name = k
 			attr2.Value = &models.ResultMessageAttributeValue{
 				DataType:    *attr.DataType,
-				StringValue: *attr.StringValue,
+				StringValue: attr.StringValue,
 			}
 		} else if k == numberAttribute {
 			attr3.Name = k
 			attr3.Value = &models.ResultMessageAttributeValue{
 				DataType:    *attr.DataType,
-				StringValue: *attr.StringValue,
+				StringValue: attr.StringValue,
 			}
 		}
 	}
 	assert.Equal(t, binaryAttribute, attr1.Name)
 	assert.Equal(t, binaryType, attr1.Value.DataType)
-	assert.Equal(t, "YmFzZTY0LWVuY29kZWQtdmFsdWU=", attr1.Value.BinaryValue) // base64 encoded value
+	assert.Equal(t, binaryValueString, attr1.Value.BinaryValue)
 
 	assert.Equal(t, stringAttribute, attr2.Name)
 	assert.Equal(t, stringType, attr2.Value.DataType)
-	assert.Equal(t, stringValue, attr2.Value.StringValue)
+	assert.Equal(t, stringValue, *attr2.Value.StringValue)
 
 	assert.Equal(t, numberAttribute, attr3.Name)
 	assert.Equal(t, numberType, attr3.Value.DataType)
-	assert.Equal(t, numberValue, attr3.Value.StringValue)
+	assert.Equal(t, numberValue, *attr3.Value.StringValue)
 }
 
 func TestSendMessageBatchV1_Xml_Success(t *testing.T) {
@@ -371,7 +373,9 @@ func TestSendMessageBatchV1_Xml_Success(t *testing.T) {
 	stringType := "String"
 	numberType := "Number"
 
-	binaryValue := "YmFzZTY0LWVuY29kZWQtdmFsdWU="
+	binaryValueString := "binary-value"
+	binaryValue := []byte(binaryValueString)
+	base64EncodedString := base64.StdEncoding.EncodeToString(binaryValue)
 	stringValue := "hogeValue"
 	numberValue := "100"
 
@@ -393,7 +397,7 @@ func TestSendMessageBatchV1_Xml_Success(t *testing.T) {
 		WithFormField("Entries.1.MessageBody", messageBody2).
 		WithFormField("Entries.1.MessageAttributes.1.Name", binaryAttribute).
 		WithFormField("Entries.1.MessageAttributes.1.Value.DataType", binaryType).
-		WithFormField("Entries.1.MessageAttributes.1.Value.BinaryValue", binaryValue).
+		WithFormField("Entries.1.MessageAttributes.1.Value.BinaryValue", base64EncodedString).
 		WithFormField("Entries.1.MessageAttributes.2.Name", stringAttribute).
 		WithFormField("Entries.1.MessageAttributes.2.Value.DataType", stringType).
 		WithFormField("Entries.1.MessageAttributes.2.Value.StringValue", stringValue).
@@ -441,26 +445,26 @@ func TestSendMessageBatchV1_Xml_Success(t *testing.T) {
 			attr2.Name = k
 			attr2.Value = &models.ResultMessageAttributeValue{
 				DataType:    *attr.DataType,
-				StringValue: *attr.StringValue,
+				StringValue: attr.StringValue,
 			}
 		} else if k == numberAttribute {
 			attr3.Name = k
 			attr3.Value = &models.ResultMessageAttributeValue{
 				DataType:    *attr.DataType,
-				StringValue: *attr.StringValue,
+				StringValue: attr.StringValue,
 			}
 		}
 	}
 	assert.Equal(t, binaryAttribute, attr1.Name)
 	assert.Equal(t, binaryType, attr1.Value.DataType)
-	assert.Equal(t, "YmFzZTY0LWVuY29kZWQtdmFsdWU=", attr1.Value.BinaryValue) // base64 encoded value
+	assert.Equal(t, binaryValueString, attr1.Value.BinaryValue)
 
 	assert.Equal(t, stringAttribute, attr2.Name)
 	assert.Equal(t, stringType, attr2.Value.DataType)
-	assert.Equal(t, stringValue, attr2.Value.StringValue)
+	assert.Equal(t, stringValue, *attr2.Value.StringValue)
 
 	assert.Equal(t, numberAttribute, attr3.Name)
 	assert.Equal(t, numberType, attr3.Value.DataType)
-	assert.Equal(t, numberValue, attr3.Value.StringValue)
+	assert.Equal(t, numberValue, *attr3.Value.StringValue)
 
 }

--- a/smoke_tests/sqs_send_message_test.go
+++ b/smoke_tests/sqs_send_message_test.go
@@ -129,34 +129,34 @@ func Test_SendMessageV1_json_with_attributes(t *testing.T) {
 			attr1.Name = k
 			attr1.Value = &models.ResultMessageAttributeValue{
 				DataType:    *attr.DataType,
-				StringValue: *attr.StringValue,
+				StringValue: attr.StringValue,
 				BinaryValue: string(attr.BinaryValue),
 			}
 		} else if k == "attr2" {
 			attr2.Name = k
 			attr2.Value = &models.ResultMessageAttributeValue{
 				DataType:    *attr.DataType,
-				StringValue: *attr.StringValue,
+				StringValue: attr.StringValue,
 				BinaryValue: string(attr.BinaryValue),
 			}
 		} else if k == "attr3" {
 			attr3.Name = k
 			attr3.Value = &models.ResultMessageAttributeValue{
 				DataType:    *attr.DataType,
-				StringValue: *attr.StringValue,
+				StringValue: attr.StringValue,
 				BinaryValue: string(attr.BinaryValue),
 			}
 		}
 	}
 	assert.Equal(t, "attr1", attr1.Name)
 	assert.Equal(t, "String", attr1.Value.DataType)
-	assert.Equal(t, "attr1_value", attr1.Value.StringValue)
+	assert.Equal(t, "attr1_value", *attr1.Value.StringValue)
 	assert.Equal(t, "attr2", attr2.Name)
 	assert.Equal(t, "Number", attr2.Value.DataType)
-	assert.Equal(t, "2", attr2.Value.StringValue)
+	assert.Equal(t, "2", *attr2.Value.StringValue)
 	assert.Equal(t, "attr3", attr3.Name)
 	assert.Equal(t, "Binary", attr3.Value.DataType)
-	assert.Equal(t, "YXR0cjNfdmFsdWU=", attr3.Value.BinaryValue) // base64 encoded "attr3_value"
+	assert.Equal(t, "attr3_value", attr3.Value.BinaryValue)
 }
 
 func Test_SendMessageV1_json_MaximumMessageSize_TooBig(t *testing.T) {
@@ -350,10 +350,10 @@ func Test_SendMessageV1_xml_with_attributes(t *testing.T) {
 	}
 	assert.Equal(t, "attr1", attr1.Name)
 	assert.Equal(t, "String", attr1.Value.DataType)
-	assert.Equal(t, "attr1_value", attr1.Value.StringValue)
+	assert.Equal(t, "attr1_value", *attr1.Value.StringValue)
 	assert.Equal(t, "attr2", attr2.Name)
 	assert.Equal(t, "Number", attr2.Value.DataType)
-	assert.Equal(t, "2", attr2.Value.StringValue)
+	assert.Equal(t, "2", *attr2.Value.StringValue)
 	assert.Equal(t, "attr3", attr3.Name)
 	assert.Equal(t, "Binary", attr3.Value.DataType)
 	assert.Equal(t, "YXR0cjNfdmFsdWU=", attr3.Value.BinaryValue) // base64 encoded "attr3_value"


### PR DESCRIPTION
We found an issue with the binary handling of MessageAttributes.

It causes the md5 hash validation error with AWS SDK for Java. Surprisingly, AWS SDK for Go does not have the md5 hash validation...