### PR TITLE
Move caser from a global variable to a local variable

### DIFF
--- a/app/models/requests.go
+++ b/app/models/requests.go
@@ -13,8 +13,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var caser = cases.Title(language.AmericanEnglish)
-
 type CreateQueueRequest struct {
 	QueueName  string            `json:"QueueName" schema:"QueueName"`
 	Attributes QueueAttributes   `json:"Attributes" schema:"Attribute"`
@@ -766,7 +764,7 @@ func (r *PublishRequest) SetAttributesFromForm(values url.Values) {
 			r.MessageAttributes = make(map[string]MessageAttribute)
 		}
 		attributes[name] = MessageAttribute{
-			DataType:    caser.String(dataType), // capitalize
+			DataType:    cases.Title(language.AmericanEnglish).String(dataType), // capitalize
 			StringValue: stringValue,
 			BinaryValue: []byte(binaryValue),
 		}


### PR DESCRIPTION
(This is split change from https://github.com/Admiral-Piett/goaws/pull/339)

# Problem 
Parallel "Publish" request to a single goaws instance will randomly corrupt DataType values like below:
- `S\u0000ring`
- `\u0000\u0000\u0000\u0000\u0000\u0000`
- `Sring\u0000`
- `S\u0000tingg`

# Cause
We should keep enclosing Caser instance in a request thread.
https://pkg.go.dev/golang.org/x/text@v0.20.0/cases#Caser
> A Caser may be stateful and should therefore not be shared between goroutines.

There is a similar issue with this problem.
https://github.com/golang/go/issues/59520

# How reproduce and confirm the fix
We faced this problem with our business application but you can reproduce the same issue with the below code.
```
var caser = cases.Title(language.AmericanEnglish)

var dataType = []string{"String", "Binary"}

func TestCaser(t *testing.T) {
	for r := 0; r < 100000; r++ {
		var wg sync.WaitGroup
		for i := 0; i < len(dataType); i++ {
			name := dataType[i]
			wg.Add(1)
			go func() {
				fmt.Println(caser.String(name))
				wg.Done()
			}()
		}
		wg.Wait()
	}
}
```
![image](https://github.com/user-attachments/assets/39b858d3-86db-47ca-8f39-5347e01b52e8)

You can confirm the fix in this PR works with this code.
```
var (
	caser = cases.Title(language.AmericanEnglish)
	mu    sync.Mutex
)

var dataType = []string{"String", "Binary"}

func formatTitle(input string) string {
	mu.Lock()
	defer mu.Unlock()
	return caser.String(input)
}

func TestCaser(t *testing.T) {
	for r := 0; r < 100000; r++ {
		var wg sync.WaitGroup
		for _, input := range dataType {
			wg.Add(1)
			go func(input string) {
				defer wg.Done()
				fmt.Println(formatTitle(input))
			}(input)
		}
		wg.Wait()
	}
}
```