### PR TITLE
Received Message Attribute via XML is not decoded from base 64

### DIFF
--- a/app/models/requests.go
+++ b/app/models/requests.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -201,12 +202,18 @@ func parseMessageAttributes(values url.Values, keyPrefix string) map[string]Mess
 		}
 
 		stringValue := values.Get(fmt.Sprintf("%s.%d.Value.StringValue", keyPrefix, i))
-		binaryValue := values.Get(fmt.Sprintf("%s.%d.Value.BinaryValue", keyPrefix, i))
+		encodedBinaryValue := values.Get(fmt.Sprintf("%s.%d.Value.BinaryValue", keyPrefix, i))
+
+		binaryValue, err := base64.StdEncoding.DecodeString(encodedBinaryValue)
+		if err != nil {
+			log.Warnf("Failed to base64 decode. %s may not have been base64 encoded.", encodedBinaryValue)
+			binaryValue = []byte(encodedBinaryValue)
+		}
 
 		result[name] = MessageAttribute{
 			DataType:    dataType,
 			StringValue: stringValue,
-			BinaryValue: []byte(binaryValue),
+			BinaryValue: binaryValue,
 		}
 	}
 

--- a/app/models/requests_test.go
+++ b/app/models/requests_test.go
@@ -317,7 +317,7 @@ func TestSendMessageRequest_SetAttributesFromForm_success(t *testing.T) {
 	attr2 := r.MessageAttributes["Attr2"]
 	assert.Equal(t, "Binary", attr2.DataType)
 	assert.Empty(t, attr2.StringValue)
-	assert.Equal(t, []uint8("VmFsdWUy"), attr2.BinaryValue)
+	assert.Equal(t, []uint8("Value2"), attr2.BinaryValue)
 }
 
 func TestSetQueueAttributesRequest_SetAttributesFromForm_success(t *testing.T) {
@@ -692,7 +692,7 @@ func TestParseMessageAttributes(t *testing.T) {
 				},
 				"Attr2": {
 					DataType:    "Binary",
-					BinaryValue: []byte("VmFsdWUy"),
+					BinaryValue: []byte("Value2"),
 				},
 			},
 		},

--- a/smoke_tests/sns_publish_test.go
+++ b/smoke_tests/sns_publish_test.go
@@ -1,6 +1,7 @@
 package smoke_tests
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
@@ -64,7 +65,92 @@ func Test_Publish_sqs_json_raw(t *testing.T) {
 	assert.Equal(t, message, *receivedMessage.Messages[0].Body)
 }
 
-func Test_Publish_Sqs_With_Message_Attributes(t *testing.T) {
+func Test_Publish_sqs_json_with_message_attributes_raw(t *testing.T) {
+	server := generateServer()
+	defer func() {
+		server.Close()
+		models.ResetResources()
+	}()
+
+	sdkConfig, _ := config.LoadDefaultConfig(context.TODO())
+	sdkConfig.BaseEndpoint = aws.String(server.URL)
+	sqsClient := sqs.NewFromConfig(sdkConfig)
+	snsClient := sns.NewFromConfig(sdkConfig)
+
+	createQueueResult, _ := sqsClient.CreateQueue(context.TODO(), &sqs.CreateQueueInput{
+		QueueName: &af.QueueName,
+	})
+
+	topicName := aws.String("unit-topic2")
+
+	createTopicResult, _ := snsClient.CreateTopic(context.TODO(), &sns.CreateTopicInput{
+		Name: topicName,
+	})
+
+	subscribeResult, _ := snsClient.Subscribe(context.TODO(), &sns.SubscribeInput{
+		Protocol:              aws.String("sqs"),
+		TopicArn:              createTopicResult.TopicArn,
+		Attributes:            map[string]string{},
+		Endpoint:              createQueueResult.QueueUrl,
+		ReturnSubscriptionArn: true,
+	})
+
+	snsClient.SetSubscriptionAttributes(context.TODO(), &sns.SetSubscriptionAttributesInput{
+		SubscriptionArn: subscribeResult.SubscriptionArn,
+		AttributeName:   aws.String("RawMessageDelivery"),
+		AttributeValue:  aws.String("true"),
+	})
+	message := "{\"IAm\": \"aMessage\"}"
+	subject := "I am a subject"
+	stringKey := "string-key"
+	binaryKey := "binary-key"
+	numberKey := "number-key"
+	stringValue := "string-value"
+	binaryValue := []byte("binary-value")
+	numberValue := "100"
+	attributes := map[string]types.MessageAttributeValue{
+		stringKey: {
+			StringValue: aws.String(stringValue),
+			DataType:    aws.String("String"),
+		},
+		binaryKey: {
+			BinaryValue: binaryValue,
+			DataType:    aws.String("Binary"),
+		},
+		numberKey: {
+			StringValue: aws.String(numberValue),
+			DataType:    aws.String("Number"),
+		},
+	}
+
+	publishResponse, publishErr := snsClient.Publish(context.TODO(), &sns.PublishInput{
+		TopicArn:          createTopicResult.TopicArn,
+		Message:           &message,
+		Subject:           &subject,
+		MessageAttributes: attributes,
+	})
+
+	receiveMessageResponse, receiveErr := sqsClient.ReceiveMessage(context.TODO(), &sqs.ReceiveMessageInput{
+		QueueUrl: createQueueResult.QueueUrl,
+	})
+
+	assert.Nil(t, publishErr)
+	assert.NotNil(t, publishResponse)
+
+	assert.Nil(t, receiveErr)
+	assert.NotNil(t, receiveMessageResponse)
+	assert.Equal(t, message, *receiveMessageResponse.Messages[0].Body)
+
+	assert.Equal(t, "649b2c548f103e499304eda4d6d4c5a2", *receiveMessageResponse.Messages[0].MD5OfBody)
+	assert.Equal(t, "ddfbe54b92058bf5b5f00055fa2032a5", *receiveMessageResponse.Messages[0].MD5OfMessageAttributes)
+
+	assert.Equal(t, stringValue, *receiveMessageResponse.Messages[0].MessageAttributes[stringKey].StringValue)
+	assert.True(t, bytes.Equal(binaryValue, receiveMessageResponse.Messages[0].MessageAttributes[binaryKey].BinaryValue))
+	assert.Equal(t, numberValue, *receiveMessageResponse.Messages[0].MessageAttributes[numberKey].StringValue)
+
+}
+
+func Test_Publish_sqs_json_with_message_attributes_not_raw(t *testing.T) {
 	server := generateServer()
 	defer func() {
 		server.Close()

--- a/smoke_tests/sqs_send_message_batch_test.go
+++ b/smoke_tests/sqs_send_message_batch_test.go
@@ -2,6 +2,7 @@ package smoke_tests
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/xml"
 	"fmt"
 	"net/http"
@@ -348,7 +349,8 @@ func TestSendMessageBatchV1_Xml_Success_including_attributes(t *testing.T) {
 	stringType := "String"
 	numberType := "Number"
 
-	binaryValue := "binary-value"
+	binaryValue := []byte("binary-value")
+	binaryValueEncodeString := base64.StdEncoding.EncodeToString([]byte("binary-value"))
 	stringValue := "string-value"
 	numberValue := "100"
 
@@ -370,7 +372,7 @@ func TestSendMessageBatchV1_Xml_Success_including_attributes(t *testing.T) {
 		WithFormField("Entries.1.MessageBody", messageBody2).
 		WithFormField("Entries.1.MessageAttributes.1.Name", binaryAttributeKey).
 		WithFormField("Entries.1.MessageAttributes.1.Value.DataType", binaryType).
-		WithFormField("Entries.1.MessageAttributes.1.Value.BinaryValue", binaryValue).
+		WithFormField("Entries.1.MessageAttributes.1.Value.BinaryValue", binaryValueEncodeString).
 		WithFormField("Entries.1.MessageAttributes.2.Name", stringAttributeKey).
 		WithFormField("Entries.1.MessageAttributes.2.Value.DataType", stringType).
 		WithFormField("Entries.1.MessageAttributes.2.Value.StringValue", stringValue).

--- a/smoke_tests/sqs_send_message_test.go
+++ b/smoke_tests/sqs_send_message_test.go
@@ -282,7 +282,7 @@ func Test_SendMessageV1_xml_with_attributes(t *testing.T) {
 		WithFormField("MessageAttribute.2.Value.StringValue", "2").
 		WithFormField("MessageAttribute.3.Name", "attr3").
 		WithFormField("MessageAttribute.3.Value.DataType", "Binary").
-		WithFormField("MessageAttribute.3.Value.BinaryValue", "attr3_value").
+		WithFormField("MessageAttribute.3.Value.BinaryValue", "YXR0cjNfdmFsdWU="). // base64 encode string attr3_value
 		Expect().
 		Status(http.StatusOK).
 		Body().Raw()


### PR DESCRIPTION
Problem:
JSON requests has decoded from base 64 on JSON marshaller, but for XML, the `SetAttributesFromForm` does not have decoding step. So internal BinaryValue was still base 64 string (as binary) value.

Fix:
Add base 64 decoding step in `SetAttributesFromForm`.